### PR TITLE
Feature/smarter paths

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -4,6 +4,7 @@ var async = require('async');
 var child = require('child_process');
 var debug = require('debug')('strong-pm');
 var fs = require('fs');
+var npmPath = require('npm-path');
 var path = require('path');
 var util = require('util');
 
@@ -37,13 +38,12 @@ Runner.prototype.start = function start() {
 
   // set PWD in env (as shell does) to the working directory, and add our
   // dependencies .bin folder to our path, so our sl-run will be found.
-  var bindir = path.resolve(module.filename, '../../node_modules/.bin');
-  var PATH = process.env.PATH || ''; // No PATH is pathological, but possible.
   var PWD = path.resolve(commit.dir, '..', 'current');
   var env = {
     PWD: PWD,
-    PATH: bindir + path.delimiter + PATH,
   };
+  // set $PATH (or %Path%) to include node and any dependencies bins
+  env[npmPath.PATH] = npmPath.get({ cwd: path.resolve(__dirname, '..') });
   this.PWD = PWD;
   this._linkPwd();
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "debug": "^0.8.1",
     "ini": "^1.2.1",
     "mkdirp": "^0.5.0",
+    "npm-path": "^1.0.1",
     "passwd-user": "git://github.com/strongloop-forks/passwd-user",
     "posix-getopt": "^1.0.0",
     "strong-service-install": "^0.1.0",


### PR DESCRIPTION
Uses a handy module, [npm-path](/timoxley/npm-path), for constructing an `npm run-script` like PATH for use in the deployed applications' environment.

The second commit goes a step further and adds the deploy application's dependencies path to the PATH. This may or may not be desired.

@sam-github any suggestions on the easiest way to test this in various scenarios? Publish to the staging registry?
