### PR TITLE
Use upstream passwd-user

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,15 +38,12 @@
     "ini": "^1.2.1",
     "mkdirp": "^0.5.0",
     "npm-path": "^1.0.1",
-    "passwd-user": "git://github.com/strongloop-forks/passwd-user",
+    "passwd-user": "^1.0.0",
     "posix-getopt": "^1.0.0",
     "strong-control-channel": "^0.2.2",
     "strong-service-install": "^0.1.0",
     "strong-supervisor": "^0.3.0",
     "tar": "^1.0.0",
     "uid-number": "0.0.5"
-  },
-  "bundleDependencies": [
-    "passwd-user"
-  ]
+  }
 }


### PR DESCRIPTION
Fork no longer needed now that sindresorhus/passwd-user#2 has been
merged and published (as 1.0.0).

This is pretty uncontroversial...

@sam-github @kraman PTAL.
