### PR TITLE
Always chown basedir

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -245,21 +245,19 @@ function ensureBaseDir(options, cb) {
     if (err) {
       console.error('Error creating base directory %s: %s', made, err.message);
     }
-    if (made) {
-      uidNumber(options.user, options.group, function(err, uid, gid) {
-        if (err) {
-          console.error('Error getting numeric uid/gid of %s/%s: %s',
-                        options.user, options.group, err.message);
-          return cb(err);
-        }
-        fs.chown(made, uid, gid, function(err) {
-          if (err)
-            console.error('Error setting ownership of base directory %s: %s',
-                          made, err.message);
-          cb(err);
-        });
+    made = made || options.pmBaseDir;
+    uidNumber(options.user, options.group, function(err, uid, gid) {
+      if (err) {
+        console.error('Error getting numeric uid/gid of %s/%s: %s',
+                      options.user, options.group, err.message);
+        return cb(err);
+      }
+      fs.chown(made, uid, gid, function(err) {
+        if (err)
+          console.error('Error setting ownership of base directory %s: %s',
+                        made, err.message);
+        cb(err);
       });
-    }
-    cb(err);
+    });
   });
 }


### PR DESCRIPTION
Always chown basedir, even if it existed before we tried to mkdirp it.

Fixes #36
