### PR TITLE
Restart current deployment with appropriate configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,13 +159,15 @@ exports.deploy = function deploy(argv, callback) {
       var currentSymlink = this.git.workdir({id: 'current'});
       var self = this;
 
-      fs.readlink(currentSymlink, function(err, id) {
+      fs.readlink(currentSymlink, function(err, resolvedPath) {
         if (err) return;
 
-        var dir = self.git.workdir({id: id});
+        resolvedPath = resolvedPath.split(path.sep);
+        var repo = resolvedPath[0];
+        var id = resolvedPath[1];
+        var dir = self.git.workdir({id: id, repo: repo});
         var hash = id.split('.')[0];
-        // XXX(sam) repo not passed? config won't be correct!
-        var commit = cicadaCommit({hash: hash, id: id, dir: dir});
+        var commit = cicadaCommit({hash: hash, id: id, dir: dir, repo: repo});
         commit.config = configForCommit(config, commit);
         runner.run(commit);
       });

--- a/lib/pack-receiver.js
+++ b/lib/pack-receiver.js
@@ -20,9 +20,15 @@ PackReceiver.prototype.sendError = function (res, err) {
 PackReceiver.prototype.processTarball = function (req, res, tarGzPath, hash) {
   var that = this;
 
+  var parsedUrl = url.parse(req.url);
+  var repo = 'default';
+  if (parsedUrl.pathname && parsedUrl.pathname !== '') {
+    repo = parsedUrl.pathname.slice(1) || 'default';
+  }
   var id = hash + '.' + Date.now();
   var untarDir = this.cicada.workdir({
-    'id': id
+    'id': id,
+    'repo': repo
   });
   var tarGzStream = fs.createReadStream(tarGzPath);
   var untar = tar.Extract({
@@ -44,12 +50,6 @@ PackReceiver.prototype.processTarball = function (req, res, tarGzPath, hash) {
   });
 
   untarStream.on('end', function() {
-    var parsedUrl = url.parse(req.url);
-    var repo = 'default';
-    if (parsedUrl.pathname && parsedUrl.pathname !== '') {
-      repo = parsedUrl.pathname.slice(1) || 'default';
-    }
-
     var branch = 'npm-pack';
     var commit = cicadaCommit({
       'hash': hash,

--- a/lib/receive.js
+++ b/lib/receive.js
@@ -15,7 +15,13 @@ exports.listen = function listen(port, base) {
   server = http.createServer(requestDemux);
   server.listen(port);
 
-  var git = cicada(path.resolve(base));
+  var workdir = path.resolve(base, 'work');
+  var git = cicada(path.resolve(base), {
+    workdir: function(target) {
+      var repo = target.repo || '';
+      return path.join(workdir, repo, target.id);
+    }
+  });
 
   server.git = git;
   server.tar = packReceiver(git);

--- a/lib/run.js
+++ b/lib/run.js
@@ -41,7 +41,7 @@ Runner.prototype.start = function start() {
 
   // set PWD in env (as shell does) to the working directory, and add our
   // dependencies .bin folder to our path, so our sl-run will be found.
-  var PWD = path.resolve(commit.dir, '..', 'current');
+  var PWD = path.resolve(commit.dir, '..', '..', 'current');
   var env = {
     PWD: PWD,
   };
@@ -90,7 +90,8 @@ Runner.prototype._linkPwd = function _linkPwd() {
   }
   // XXX(sam) catch errors here? this is unexpected... can't do much but log
   // and keep going
-  fs.symlinkSync(path.basename(this.commit.dir), this.PWD);
+  var workdir = path.dirname(this.PWD);
+  fs.symlinkSync(path.relative(workdir, this.commit.dir), this.PWD);
 };
 
 Runner.prototype.onExit = function onExit(code, signal) {


### PR DESCRIPTION
Hello, guys! This commit gonna help to resolve to strongloop/strong-pm#15.

Thus `cicada` allows to pass custom `workdir` function we can have commit work directory pattern: `workdir/reponame/id` instead of `workdir/id`. This helps to determine repository name on restart and pick up right configuration. So files get copied, start / stop commands are the same as on deploy time.

What do you think?
