### PR TITLE
Don't crash on runner exit after soft-stop

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -165,7 +165,7 @@ Runner.prototype.softStop = function softStop(callback) {
   self.request({cmd: 'stop'}, function(rsp) {
     debug('stop response: %j', rsp);
   });
-  self.on('exit', function(status) {
+  self.once('exit', function(status) {
     return callback(status);
   });
   return this;

--- a/test/test-pmctl-local.js
+++ b/test/test-pmctl-local.js
@@ -151,6 +151,12 @@ function test(port) {
 
   expect('set-size 1');
   waiton('status', /worker count: *1/);
+
+  waiton('restart', 'stopped with status SIGTERM, restarting');
+  waiton('status', /worker count: *0/);
+  expect('set-size 1');
+  waiton('status', /worker count: *1/);
+
   expect('cpu-start 0', /Profiler started/);
 
   if (process.env.STRONGLOOP_LICENSE) {


### PR DESCRIPTION
When issuing a soft-stop (either directly or via soft-restart) the
runner registered an event handler for 'exit' with the callback that
is given. Because that callback eventually bubbles up to a beforeCreate
hook on a ServerAction model instance, a phantom response is sent at
any point in the future when the runner emits an 'exit' event. This
manifests as Express throwing an exception because the callback
ultimately attempts to send a response, complete with new response
headers, on a response that has already been sent.

This went unnoticed because the tests did not trigger any restarts
after the soft-restart test and because there is no soft-stop test.
