### PR TITLE
Add option for setting environment during service installation

### DIFF
--- a/bin/sl-pm-install.usage
+++ b/bin/sl-pm-install.usage
@@ -7,6 +7,9 @@ Options:
                       deployed applications.
   -b,--base BASE      Base directory to work in (default is .strong-pm).
   -c,--config CONFIG  Config file (default BASE/config).
+  -e,--set-env K=V... Initial application environment variables. If
+                      setting multiple variables they must be quoted
+                      into a single argument: "K1=V1 K2=V2 K3=V3".
   -u,--user USER      User to run manager as (default is strong-pm).
   -p,--port PORT      Listen on PORT for application deployment (no
                       default).

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,6 +1,7 @@
 var async = require('async');
 var child_process = require('child_process');
 var debug = require('debug')('strong-pm:install');
+var Environment = require('./env');
 var fs = require('fs');
 var mkdirp = require('mkdirp');
 var Parser = require('posix-getopt').BasicParser;
@@ -27,6 +28,7 @@ function install(argv, callback) {
       'h(help)',
       'b:(base)',
       'c:(config)',
+      'e:(set-env)',
       'u:(user)',
       'p:(port)',
       'j:(job-file)',
@@ -49,6 +51,7 @@ function install(argv, callback) {
     force: false,
     upstart: '1.4',
     env: {},
+    pmEnv: '',
   };
 
   while ((option = parser.getopt()) !== undefined) {
@@ -64,6 +67,9 @@ function install(argv, callback) {
         break;
       case 'c':
         jobConfig.pmConfigFile = option.optarg;
+        break;
+      case 'e':
+        jobConfig.pmEnv = option.optarg;
         break;
       case 'p':
         jobConfig.pmPort = option.optarg | 0; // cast to an integer
@@ -118,6 +124,7 @@ function install(argv, callback) {
   var steps = [
     ensureUser, fillInGroup, fillInHome,
     setCommand, ensureBaseDir,
+    seedEnvironment,
     ensureOwner, slServiceInstall
   ].map(w);
 
@@ -289,5 +296,51 @@ function ensureOwner(options, callback) {
                         });
       callback(err, paths);
     });
+  }
+}
+
+function seedEnvironment(options, callback) {
+  if (options.pmEnv) {
+    debug('extracting from: %j', options.pmEnv);
+    return extractEnv(options.pmEnv, writeEnv);
+  } else {
+    return setImmediate(callback);
+  }
+
+  function writeEnv(err, env) {
+    if (err) {
+      return callback(err);
+    }
+    var envPath = path.resolve(options.pmBaseDir, 'env.json');
+    var store = new Environment(envPath);
+    debug('Seeding env with: %j', env);
+    for (var k in env) {
+      store.set(k, env[k]);
+    }
+    if (options.dryRun) {
+      console.log('Would seed environment with: %j', env);
+      callback();
+    } else {
+      store.save(callback);
+    }
+  }
+
+  function extractEnv(envOrPath, callback) {
+    setImmediate(callback, null, parseEnvString(envOrPath));
+
+    function parseEnvString(str) {
+      var env = {};
+      str.split(/\s+/)
+         .map(trim)
+         .forEach(function(pair) {
+           var kv = pair.split('=', 2);
+           env[kv[0]] = kv[1];
+         });
+      return env;
+
+      function trim(s) {
+        return s.trim();
+      }
+    }
   }
 }

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -31,7 +31,7 @@ $test = <<SCRIPT
     ## ($* > /dev/null && echo "ok # $*") || (echo "not ok # $*" >&2)
   }
   report npm install -g strong-pm.tgz
-  report sudo sl-pm-install --port 7777
+  report sudo sl-pm-install --port 7777 --set-env SL_PM_VAGRANT=42
   report test -f /etc/init/strong-pm.conf
   report sudo start strong-pm
   report sudo status strong-pm

--- a/test/test-end-to-end.sh
+++ b/test/test-end-to-end.sh
@@ -37,6 +37,11 @@ while ! curl -sI http://localhost:8888/this/is/a/test; do
   sleep 5
 done
 
+curl -s http://localhost:8888/env \
+  | grep -F -e '"SL_PM_VAGRANT": "42"' \
+  && echo 'ok # seed environment includes SL_PM_VAGRANT=42 via pm-install' \
+  || echo 'not ok # failed to set SL_PM_VAGRANT=42 via pm-install'
+
 curl -s http://localhost:8888/this/is/a/test \
   | grep -F -e '/this/is/a/test' \
   && echo 'ok # echo server responded' \

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -25,12 +25,17 @@ assert_exit 1 $CMD --dry-run --port 0
 # should fail when given user doesn't actually exist
 assert_exit 1 $CMD --dry-run --port 7777 --user definitely-does-not-exist
 
+echo "FOO=bar BAR=foo" > $TMP/input.env
+echo "MORE=less LESS=more" >> $TMP/input.env
+
 # Should create an upstart job at the specified path
-assert_exit 0 $CMD --port 7777 \
-              --job-file $TMP/upstart.conf \
-              --user `id -un` \
-              --metrics statsd: \
-              --base $TMP/deeply/nested/sl-pm
+$CMD --port 7777 \
+     --job-file $TMP/upstart.conf \
+     --user `id -un` \
+     --metrics statsd: \
+     --set-env "$(cat $TMP/input.env)" \
+     --base $TMP/deeply/nested/sl-pm 2>&1 \
+|| fail "Failed to run install"
 
 # Should match what was specified
 assert_file $TMP/upstart.conf "--listen 7777"
@@ -45,6 +50,12 @@ assert_file $TMP/upstart.conf "--config $TMP/deeply/nested/sl-pm/config"
 
 # Should create base for us
 assert_exit 0 test -d $TMP/deeply/nested/sl-pm
+
+# Should create initial environment file with FOO and BAR in it
+assert_file $TMP/deeply/nested/sl-pm/env.json '"FOO":"bar"'
+assert_file $TMP/deeply/nested/sl-pm/env.json '"BAR":"foo"'
+assert_file $TMP/deeply/nested/sl-pm/env.json '"MORE":"less"'
+assert_file $TMP/deeply/nested/sl-pm/env.json '"LESS":"more"'
 
 unset SL_PM_INSTALL_IGNORE_PLATFORM
 assert_report


### PR DESCRIPTION
- [x] Add `--env ENV` option to set initial environment for deployed application
- [x] Update pm-install usage output

Based off of #47 
For strongloop-internal/scrum-nodeops#99
