### PR TITLE
internal: use persisted environment for --metrics

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -52,6 +52,7 @@ function install(argv, callback) {
     upstart: '1.4',
     env: {},
     pmEnv: '',
+    pmSeedEnv: {},
   };
 
   while ((option = parser.getopt()) !== undefined) {
@@ -90,7 +91,7 @@ function install(argv, callback) {
         jobConfig.upstart = option.optarg;
         break;
       case 'm':
-        jobConfig.env.STRONGLOOP_METRICS = option.optarg;
+        jobConfig.pmSeedEnv.STRONGLOOP_METRICS = option.optarg;
         break;
       default:
         console.error('Invalid usage (near option \'%s\'), try `%s --help`.',
@@ -124,7 +125,8 @@ function install(argv, callback) {
   var steps = [
     ensureUser, fillInGroup, fillInHome,
     setCommand, ensureBaseDir,
-    seedEnvironment,
+    prepareSeedEnvironment,
+    writeSeedEnvironment,
     ensureOwner, slServiceInstall
   ].map(w);
 
@@ -299,48 +301,44 @@ function ensureOwner(options, callback) {
   }
 }
 
-function seedEnvironment(options, callback) {
-  if (options.pmEnv) {
-    debug('extracting from: %j', options.pmEnv);
-    return extractEnv(options.pmEnv, writeEnv);
+function prepareSeedEnvironment(options, callback) {
+  options.pmEnv = options.pmEnv || '';
+  debug('extracting from: %j', options.pmEnv);
+  options.pmEnv
+    .split(/\s+/)
+    .map(trim)
+    .forEach(function(pair) {
+      var kv = pair.split('=', 2);
+      options.pmSeedEnv[kv[0]] = kv[1];
+    });
+
+  return setImmediate(callback);
+
+  function trim(s) {
+    return s.trim();
+  }
+}
+
+function writeSeedEnvironment(options, callback) {
+  if (Object.keys(options.pmSeedEnv).length > 0) {
+    var envPath = path.resolve(options.pmBaseDir, 'env.json');
+    return writeEnv(options.pmSeedEnv, envPath, callback);
   } else {
+    debug('no seed environment');
     return setImmediate(callback);
   }
 
-  function writeEnv(err, env) {
-    if (err) {
-      return callback(err);
-    }
-    var envPath = path.resolve(options.pmBaseDir, 'env.json');
-    var store = new Environment(envPath);
-    debug('Seeding env with: %j', env);
+  function writeEnv(env, path, cb) {
+    debug('setting seed env: %j', env);
+    var store = new Environment(path);
     for (var k in env) {
       store.set(k, env[k]);
     }
     if (options.dryRun) {
       console.log('Would seed environment with: %j', env);
-      callback();
+      return cb();
     } else {
-      store.save(callback);
-    }
-  }
-
-  function extractEnv(envOrPath, callback) {
-    setImmediate(callback, null, parseEnvString(envOrPath));
-
-    function parseEnvString(str) {
-      var env = {};
-      str.split(/\s+/)
-         .map(trim)
-         .forEach(function(pair) {
-           var kv = pair.split('=', 2);
-           env[kv[0]] = kv[1];
-         });
-      return env;
-
-      function trim(s) {
-        return s.trim();
-      }
+      store.save(cb);
     }
   }
 }

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -39,7 +39,6 @@ $CMD --port 7777 \
 
 # Should match what was specified
 assert_file $TMP/upstart.conf "--listen 7777"
-assert_file $TMP/upstart.conf "env STRONGLOOP_METRICS=statsd:"
 assert_file $TMP/upstart.conf "--base $TMP/deeply/nested/sl-pm"
 
 # Should actually point to strong-pm
@@ -50,6 +49,9 @@ assert_file $TMP/upstart.conf "--config $TMP/deeply/nested/sl-pm/config"
 
 # Should create base for us
 assert_exit 0 test -d $TMP/deeply/nested/sl-pm
+
+# Should put --metrics into STRONGLOOP_METRICS in seed environment
+assert_file $TMP/deeply/nested/sl-pm/env.json '"STRONGLOOP_METRICS":"statsd:"'
 
 # Should create initial environment file with FOO and BAR in it
 assert_file $TMP/deeply/nested/sl-pm/env.json '"FOO":"bar"'


### PR DESCRIPTION
Move the STRONGLOOP_METRICS environment variable out of the Upstart job
and into the initial persisted environment.

@sam-github As discussed in this morning's standup.
/cc @kraman @chandadharap 
