### PR TITLE
Support installing strong-pm as a systemd service

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -35,6 +35,7 @@ function install(argv, callback) {
       'n(dry-run)',
       'f(force)',
       'i:(upstart)', // -i unused, posix-getopt doesn't do long-only options
+      's(systemd)',
       'm:(metrics)',
     ].join(''),
     argv);
@@ -49,7 +50,8 @@ function install(argv, callback) {
     dryRun: false,
     jobFile: '/etc/init/strong-pm.conf',
     force: false,
-    upstart: '1.4',
+    upstart: false,
+    systemd: false,
     env: {},
     pmEnv: '',
     pmSeedEnv: {},
@@ -90,6 +92,9 @@ function install(argv, callback) {
       case 'i': // actually --upstart
         jobConfig.upstart = option.optarg;
         break;
+      case 's':
+        jobConfig.systemd = true;
+        break;
       case 'm':
         jobConfig.pmSeedEnv.STRONGLOOP_METRICS = option.optarg;
         break;
@@ -117,8 +122,17 @@ function install(argv, callback) {
       return callback(Error('platform'));
   }
 
-  if (jobConfig.upstart !== '0.6' && jobConfig.upstart !== '1.4') {
-    console.error('Invalid usage (only upstart "0.6" and "1.4" supported)');
+  if (!jobConfig.systemd && !jobConfig.upstart) {
+    jobConfig.upstart = '1.4'; // default
+  } else if (jobConfig.systemd && jobConfig.upstart) {
+    console.error('Invalid usage (cannot specify both --systemd and --upstart)' +
+                  ', see `%s --help`', $0);
+    return callback(Error('usage'));
+  }
+  if (!jobConfig.systemd &&
+      jobConfig.upstart !== '0.6' && jobConfig.upstart !== '1.4') {
+    console.error('Invalid usage (only upstart "0.6" and "1.4" supported)' +
+                  ', see `%s --help`', $0);
     return callback(Error('usage'));
   }
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "strong-control-channel": "^1",
     "strong-mesh-models": "^2.0.0",
     "strong-npm-ls": "^1.0.0",
-    "strong-service-install": "^1.0.0",
+    "strong-service-install": "^1.1.0",
     "strong-supervisor": "^1.0.0",
     "tar": "^1.0.0",
     "uid-number": "0.0.5"

--- a/test/test-install-systemd.sh
+++ b/test/test-install-systemd.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+source common.sh
+
+# Setup
+CMD="node ../bin/sl-pm-install.js"
+TMP=`mktemp -d -t sl-svc-installXXXXXX`
+echo "# using tmpdir: $TMP"
+
+export SL_PM_INSTALL_IGNORE_PLATFORM=true
+
+# Should create a systemd service at the specified path
+assert_exit 0 $CMD --port 7777 \
+              --job-file $TMP/systemd.service \
+              --user `id -un` \
+              --base $TMP/deeply/nested/sl-pm \
+              --systemd
+
+# Simple lines that should be in the service file for this config
+assert_file $TMP/systemd.service "ExecStart=$(which node)"
+assert_file $TMP/systemd.service "WorkingDirectory=$HOME"
+
+unset SL_PM_INSTALL_IGNORE_PLATFORM
+assert_report

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -17,10 +17,13 @@ assert_exit 0 $CMD --help
 # dry-run should not fail
 assert_exit 0 $CMD --dry-run --port 7777 --user `id -un`
 
+# fails if attempting to use upstart systemd at the same time
+assert_exit 1 $CMD --dry-run --port 7777 --user `id -un` --upstart 0.6 --systemd
+
 # requires a valid port
-assert_exit 1 $CMD --dry-run --port ''
-assert_exit 1 $CMD --dry-run --port abc
-assert_exit 1 $CMD --dry-run --port 0
+assert_exit 1 $CMD --dry-run --user `id -un` --port ''
+assert_exit 1 $CMD --dry-run --user `id -un` --port abc
+assert_exit 1 $CMD --dry-run --user `id -un` --port 0
 
 # should fail when given user doesn't actually exist
 assert_exit 1 $CMD --dry-run --port 7777 --user definitely-does-not-exist


### PR DESCRIPTION
Use systemd support in strong-service-install@1.1.0 to install
strong-pm as a systemd Service with the same level of support as
Upstart.
- Depends on strongloop/strong-service-install#5
- Closes #25
- Closes strongloop-internal/scrum-nodeops#19
