### PR TITLE
Delete metrics older than 5 min on metrics update

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -248,7 +248,7 @@ Server.prototype._onMetrics = function _onMetrics(req, callback) {
 
   async.each(Object.keys(req.metrics.processes), saveMetric, function(err) {
     assert.ifError(err);
-    if (callback) callback(err);
+    deleteOld();
   });
 
   function saveMetric(wid, asyncCb) {
@@ -267,6 +267,17 @@ Server.prototype._onMetrics = function _onMetrics(req, callback) {
       m.workerId = wid;
       m.timeStamp = req.metrics.timestamp;
       Metric.upsert(m, asyncCb);
+    });
+  }
+
+  function deleteOld() {
+    var now = new Date().getTime();
+    var where = {
+      timeStamp: {lt: now - 5 * 60 * 1000},
+    };
+    Metric.destroyAll(where, function(err) {
+      assert.ifError(err);
+      if (callback) return callback(err);
     });
   }
 };


### PR DESCRIPTION
Note that if no metrics updates arrived, then the old metrics won't be
deleted.

Final PR for https://github.com/strongloop-internal/scrum-nodeops/issues/146
