### PR TITLE
Use compression directly

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -16,6 +16,7 @@ var prepare = require('./prepare').prepare;
 var runner = require('./run');
 var setupPushReceiver = require('./receive').setupPushReceiver;
 var util = require('util');
+var compression = require('compression');
 
 // Extend base without modifying it.
 function extend(base, extra) {
@@ -38,7 +39,7 @@ function Server(originalCommand, configPath, baseDir, listenPort, controlPath) {
   this._app.use(loopback.favicon());
 
   // request pre-processing middleware
-  this._app.use(loopback.compress());
+  this._app.use(compression());
 
   // boot scripts mount components like REST API
   loopbackBoot(this._app, path.join(__dirname, 'server'));


### PR DESCRIPTION
Instead of using the `loopback.compress()` shortcut... this patch now uses the `compression` middleware directly. The shortcut has [some known issues](https://github.com/strongloop/loopback/issues/833).

/to @kraman 
/cc @sam-github @bajtos 
