### PR TITLE
locked mode: reject all deployment attempts

### DIFF
--- a/lib/ctl.js
+++ b/lib/ctl.js
@@ -4,6 +4,9 @@ var path = require('path');
 
 function onCtlRequest(options, req, callback) {
   debug('request %j', req);
+  if (process.env.STRONG_PM_LOCKED) {
+    return onCtlRequestLocked(options, req, callback);
+  }
 
   var app = options.app;
   var runner = options.runner;
@@ -70,6 +73,41 @@ function onCtlRequest(options, req, callback) {
 
   if (rsp) {
     debug('response:', rsp);
+
+    process.nextTick(callback.bind(null, rsp));
+  }
+}
+
+var ALLOWED_SUB_WHEN_LOCKED = [
+  'status',
+  'start-tracking-objects',
+  'stop-tracking-objects',
+  'start-cpu-profiling',
+  'stop-cpu-profiling',
+  'heap-snapshot',
+  'npm-ls'
+];
+
+function onCtlRequestLocked(options, req, callback) {
+  debug('request [LOCKED] %j', req);
+
+  var runner = options.runner;
+  var current = runner.current();
+  var cmd = req.cmd;
+  var sub = req.sub;
+  var rsp = {}; // Clear this response if the handler will callback itself.
+
+  if (req.cmd === 'status') {
+    rsp = status(options, callback);
+  } else if (req.cmd === 'current' &&
+             ALLOWED_SUB_WHEN_LOCKED.indexOf(req.sub) >= 0) {
+    rsp = requestOfCurrent(current, req, rsp, callback);
+  } else {
+    rsp.error = 'unsupported';
+  }
+
+  if (rsp) {
+    debug('response [LOCKED]:', rsp);
 
     process.nextTick(callback.bind(null, rsp));
   }


### PR DESCRIPTION
Respond to all deployment attempts of any kind with a 403 Forbidden
when the STRONG_PM_LOCKED environment variable is set to any non-blank
value.

This feature is primarily for strongloop/strong-arc#656, so the feature
is intentionally undocumented until we decide if/how we want to surface
it in a maintainable way.

/cc @chandadharap @altsang @kraman 
