### PR TITLE
Support sl-run spawn on Windows

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -54,6 +54,8 @@ Runner.prototype.start = function start() {
   if (!commit.runInPlace) this._linkPwd();
 
   // set $PATH (or %Path%) to include node and any dependencies bins
+  // XXX(sam) useless, node scripts aren't executable on windows, remove with
+  // the config file ASAP
   commit.env[npmPath.PATH] = npmPath.get({
     env: process.env,
     cwd: path.resolve(__dirname, '..'),
@@ -61,7 +63,14 @@ Runner.prototype.start = function start() {
 
   debug('start with command `%s` env %j', cmd, commit.env);
 
-  this.child = commit.spawn(cmd, {
+  var args = cmd.split(/\s+/); // tokenize into args array
+
+  if (args[0] === 'sl-run')
+    args[0] = require.resolve('strong-supervisor/bin/sl-run');
+
+  debug('spawn: %s, %j', process.execPath, args);
+
+  this.child = commit.spawn(process.execPath, args, {
     // cwd: commit.spawn sets this to working directory for commit
     env: extend(process.env, commit.env),
     stdio: [0, 1, 2, 'ipc'],


### PR DESCRIPTION
We were injecting all our dependencies .bin dirs into our path, and
expecting spawn would find them. On Windows, node scripts aren't
executable, so it doesn't matter if they are in the PATH. So, we
tokenize the start command, naively, but good enough for now
(configurability of the start command is going away ASAP), and spawn
node to execute the supervisor script.
