### PR TITLE
Fix mesh model resolution to use module name

### DIFF
--- a/lib/server/model-config.json
+++ b/lib/server/model-config.json
@@ -2,7 +2,7 @@
   "_meta": {
     "sources": [
       "../models",
-      "../../node_modules/strong-mesh-models/models"
+      "strong-mesh-models/models"
     ]
   },
   "User": {


### PR DESCRIPTION
This is better than using relative path since it allows mesh models to
be a dependency of the parent project.
