### PR TITLE
Update version to reflect new one-shot feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strong-pm",
   "description": "StrongLoop Process Manager",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "keywords": [
     "StrongLoop",
     "agent",
@@ -82,7 +82,7 @@
     "strong-mesh-models": "^3.0.0",
     "strong-npm-ls": "^1.0.0",
     "strong-service-install": "^1.1.0",
-    "strong-supervisor": "^1.0.0",
+    "strong-supervisor": "^1.4.0",
     "tar": "^1.0.0",
     "uid-number": "0.0.5"
   }


### PR DESCRIPTION
strong-supervisor 1.4 supports run-but-do-not-restart clustering, a
feature that  arc via pm (albeit with zero code change in pm itself).
Since strong-arc will depend on that supervisor feature, and strong-pm
needs to increment is minor to reflect it supports this new feature.

For https://github.com/strongloop-internal/scrum-nodeops/issues/240