### PR TITLE
Fix metrics process id assignment

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -262,7 +262,7 @@ Server.prototype._onMetrics = function _onMetrics(req, callback) {
 
   function saveMetric(wid, asyncCb) {
     var m = req.metrics.processes[wid];
-    var q = {where: {serviceInstanceId: 1, workerId: +wid}};
+    var q = {where: {serviceInstanceId: 1, workerId: +wid, stopTime: null}};
     Process.findOne(q, function(err, proc) {
       assert.ifError(err);
       if (!proc) {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "lodash": "^2.4.1",
     "loopback": "^2.4.0",
     "loopback-boot": "^2.1.0",
-    "loopback-datasource-juggler": "^2.9.0",
+    "loopback-datasource-juggler": "^2.13.0",
     "loopback-explorer": "^1.5.1",
     "mkdirp": "^0.5.0",
     "npm-path": "^1.0.1",


### PR DESCRIPTION
Ensure that the process ID that is assigned to the metrics object
reflects a currently running process.