### PR TITLE
test: rewrote pmctl-local to not use shelljs

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -27,6 +27,8 @@ var Server = require('../lib/server');
 exports.ok = false;
 
 process.on('exit', function(code) {
+  if (exports.ok === undefined)
+    return; // Test isn't using the OK check
   if (code === 0) {
     assert(exports.ok, 'test did not set OK before exit');
     console.log('PASS');

--- a/test/test-pmctl-local.js
+++ b/test/test-pmctl-local.js
@@ -3,20 +3,127 @@ var childctl = require('strong-control-channel/process');
 var cp = require('child_process');
 var debug = require('debug')('strong-pm:test');
 var fs = require('fs');
-var helper = require('./helper');
 var path = require('path');
+var tap = require('tap');
 var util = require('util');
 
-require('shelljs/global');
+var pm;
+var port;
 
-process.env.STRONGLOOP_CLUSTER = 0;
+function setup(t) {
+  var helper = require('./helper');
+  delete helper.ok; // Use tap to determine ok
 
-console.log('Done setup, run process manager');
+  process.env.STRONGLOOP_CLUSTER = 0;
 
-function onReceive() {
+  t.test('setup', {timeout: 10000}, function(t) {
+    if (port) {
+      t.assert(true, 'reuse pm setup');
+      return t.end();
+    }
+    _pm = manager(function(_port) {
+      var pmurl = util.format('http://127.0.0.1:%d/default', _port);
+      console.log('pmurl: %s', pmurl);
+
+      cp.exec(util.format('git push %s master:master', pmurl), function(er) {
+        assert.ifError(er);
+        port = _port;
+        pm = _pm;
+        t.assert(true, 'pm started on port ' + _port);
+        t.end();
+      });
+    });
+  });
+
+  waiton(t, 'status', /current:$/m);
 }
 
-helper.manager = function manager(callback) {
+function expect(t, cmd, pattern) {
+  var name = 'expect: ' + cmd + ' ' + (pattern || '');
+  t.test(name, function(t) {
+    console.log("START %s", name);
+    pmctl(cmd, function(out) {
+      console.log("check %s with pattern %j against code: %j",
+        name, pattern, out.code);
+
+      t.equal(out.code, 0, 'pmctl exit code');
+
+      if (out.code == 0)
+        t.assert(checkOutput(out, pattern), pattern || '(no pattern)');
+
+      if (out.code != 0 || !checkOutput(out, pattern))
+        console.log('check failed against: <\n%>', out.output);
+      t.end();
+    });
+  });
+}
+
+function waiton(t, cmd, pattern) {
+  var name = 'waiton: ' + cmd + ' ' + (pattern || '');
+  t.test(name, {timeout: 10000}, function(t) {
+    console.log("START %s", name);
+    check();
+
+    function check() {
+      pmctl(cmd, function(out) {
+        console.log("check %s against code: %j", name, out.code);
+        if (out.code == 0 && checkOutput(out, pattern)) {
+          t.equal(out.code, 0, 'pmctl exit code');
+          t.assert(true, pattern || '(no pattern)');
+          t.end();
+          return;
+        }
+        setTimeout(check, 1000);
+      });
+    }
+  });
+}
+
+function failon(t, cmd, pattern) {
+  var name = 'failon: ' + cmd + ' ' + (pattern || '');
+  t.test(name, function(t) {
+    console.log("START %s", name);
+    pmctl(cmd, function(out) {
+      console.log("check %s against code: %j", name, out.code);
+
+      t.notEqual(out.code, 0);
+      // FIXME(sam) output assertions were missing from the original, I'll
+      // add them back in once I know the original test passes, because
+      // the patterns may not be correct
+      // t.assert(checkOutput(out, pattern), pattern || '(no pattern)');
+      t.end();
+    });
+  });
+}
+
+function pmctl(cmd, callback) {
+  var cli = require.resolve('../bin/sl-pmctl.js');
+  cmd = process.execPath + ' ' + cli + ' ' + cmd;
+  return cp.exec(cmd, function(er, stdout, stderr) {
+    var out = {
+      out: stdout.trim(),
+      err: stderr.trim(),
+      output: stdout + '\n' + stderr,
+      code: er ? er.code : 0
+    };
+    debug('Run: %s => %s out <\n%s>\nerr <\n%s>',
+      cmd, out.code, out.out, out.err);
+    return callback(out);
+  });
+}
+
+function checkOutput(out, pattern) {
+  if (!pattern)
+    return true;
+
+  if (typeof pattern === 'string')
+    pattern = RegExp(pattern);
+  if (pattern.test(out.output))
+    return true;
+  return false;
+}
+
+function manager(callback) {
   var pmcli = require.resolve('../bin/sl-pm.js');
 
   // Listened on zero to avoid port conflicts, search for actual port.
@@ -36,6 +143,9 @@ helper.manager = function manager(callback) {
 
   var ctl = childctl.attach(onReceive, pm);
 
+  function onReceive() {
+  }
+
   ctl.request({cmd: 'status'}, function (res) {
     var port = res.port;
     console.log('Listening port: %s', port);
@@ -50,162 +160,139 @@ helper.manager = function manager(callback) {
   return pm;
 };
 
-helper.pmctl = {};
-
-// Wait on cmd to write specific output
-helper.pmctl.waiton = waiton;
-function waiton(cmd, output) {
-  while (true) {
-    try {
-      console.trace('WAITON %s', cmd);
-      expect(cmd, output);
-      return;
-    } catch(er) {
-      pause();
-    }
-  }
+function test(name, callback) {
+  // XXX could skip tests here, based on presence of TAP_ONLY
+  tap.test(name, function(t) {
+    console.log('TEST:', name);
+    // XXX could set t globally here, so it doesn't have to be an explicit
+    // param of expect/failon/waiton
+    setup(t);
+    callback(t);
+  });
 }
 
-// Expect cmd to succeed and write specific output
-helper.pmctl.expect = expect;
-function expect(cmd, output) {
-  var out = pmctl(cmd);
-  console.log("EXPECT %s code: %j output: <\n%s>", cmd, out.code, out.output);
-
-  assert.equal(out.code, 0);
-  checkOutput(out, output);
-}
-
-// Expect cmd to fail and write specific output
-helper.pmctl.failon = failon;
-function failon(cmd, output) {
-  var out = pmctl(cmd);
-
-  assert.notEqual(out.code, 0);
-}
-
-function checkOutput(out, output) {
-  if (output) {
-    if (typeof output === 'string')
-      output = RegExp(output);
-    //console.log('Test <%s> against %s', out.output, output);
-    assert(output.test(out.output), out.output);
-  }
-}
-
-helper.pmctl.run = pmctl;
-function pmctl(/* cmd, arguments...*/) {
-  var cli = require.resolve('../bin/sl-pmctl.js');
-  var cmd = cli + ' ' + util.format.apply(util, arguments);
-  var out = exec(cmd, {silent: true});
-  out.output = out.output.trim();
-  console.log('Run: %s => %s <%s>', cmd, out.code, out.output.replace(/\n/g,'$\n'));
-  return out;
-}
-
-helper.pause = pause;
-function pause(secs) {
-  var secs = secs || 2;
-  var start = process.hrtime();
-  while (true) {
-    var ts = process.hrtime(start);
-    if (ts[0] >= secs)
-      return;
-  }
-}
-
-var pm = helper.manager(function(port) {
-  var pmurl = util.format('http://127.0.0.1:%d/default', port);
-  console.log('pmurl: %s', pmurl);
-
-  var out = exec(util.format('git push %s master:master', pmurl));
-  console.log('out:', out.code, out.code !== 0 ? out.output : '');
-  assert.equal(out.code, 0);
-
-  test(port);
+test('start', function(t) {
+  // Check the setup() routine starts pm
 });
 
-function test(port) {
-  console.log('Begin test:');
-  waiton('status', /current:$/m);
-  expect('--version', require('../package.json').version);
-  expect('-v', require('../package.json').version);
-  expect('--help', 'usage: ');
-  expect('-h', 'usage: ');
-  expect('', util.format('pid: *%d', pm.pid));
-  expect('ls', /test-app@/);
-  expect('ls', /buffertools@/);
-  expect('status', util.format('port: *%d', port));
-  failon('start', 'running, so cannot be started');
-  expect('stop', 'stopped with status SIGTERM');
-  waiton('status', /status: *stopped/);
-  failon('stop', 'not running, so cannot be stopped');
-  expect('start', 'starting');
-  waiton('status', /status: *started/);
-  expect('restart', 'stopped with status SIGTERM, restarting');
-  waiton('status', /status: *started/);
-  waiton('status', /worker count: *0/);
-  expect('set-size 3');
-  waiton('status', /worker count: *3/);
-  expect('soft-restart', 'stopped with status 0, restarting');
-  waiton('status', /worker count: *0/);
+test('start (again)', function(t) {
+  // Check the setup() routine short-circuits, because pm is started
+});
 
-  expect('set-size 1');
-  waiton('status', /worker count: *1/);
+test('version', function(t) {
+  expect(t, '--version', require('../package.json').version);
+  expect(t, '-v', require('../package.json').version);
+});
 
-  waiton('restart', 'stopped with status SIGTERM, restarting');
-  waiton('status', /worker count: *0/);
-  expect('set-size 1');
-  waiton('status', /worker count: *1/);
+test('help', function(t) {
+  expect(t, '--help', 'usage: ');
+  expect(t, '-h', 'usage: ');
+});
 
-  expect('env-get', 'No matching environment variables defined');
-  expect('env-get NOTSET', 'No matching environment variables defined');
+test('status has pm pid', function(t) {
+  // empty command is synonymous with 'status'
+  expect(t, '', util.format('pid: *%d', pm.pid));
+});
 
-  expect('env-set FOO=bar BAR=foo', 'Environment updated');
-  expect('env-get', /FOO=bar/);
-  expect('env-get', /BAR=foo/);
-  expect('env-get FOO', /FOO=bar/);
-  expect('env-get NOTSET', 'No matching environment variables defined');
+test('ls', function(t) {
+  expect(t, 'ls', /test-app@/);
+  expect(t, 'ls', /buffertools@/);
+});
 
-  expect('env-unset FOO', 'Environment updated');
-  expect('env-get', /BAR=foo/);
-  expect('env-get FOO', 'No matching environment variables defined');
+test('status, start, stop, etc.', function(t) {
+  expect(t, 'set-size 0');
+  waiton(t, 'status', /worker count: *0/);
 
-  expect('set-size 1');
-  waiton('status', /worker count: *1/);
+  expect(t, 'status', util.format('port: *%d', port));
+  failon(t, 'start', 'running, so cannot be started');
+  expect(t, 'stop', 'stopped with status SIGTERM');
+  waiton(t, 'status', /status: *stopped/);
+  failon(t, 'stop', 'not running, so cannot be stopped');
+  expect(t, 'start', 'starting');
+  waiton(t, 'status', /status: *started/);
+  expect(t, 'restart', 'stopped with status SIGTERM, restarting');
+  waiton(t, 'status', /status: *started/);
+  waiton(t, 'status', /worker count: *0/);
+  expect(t, 'set-size 3');
+  waiton(t, 'status', /worker count: *3/);
+  expect(t, 'soft-restart', 'stopped with status 0, restarting');
+  waiton(t, 'status', /worker count: *0/);
 
-  expect('cpu-start 0', /Profiler started/);
-  expect('cpu-stop 0', /CPU profile written.*node.0.cpuprofile/);
+  expect(t, 'set-size 1');
+  waiton(t, 'status', /worker count: *1/);
+
+  waiton(t, 'restart', 'stopped with status SIGTERM, restarting');
+  waiton(t, 'status', /worker count: *0/);
+});
+
+test('env get, set, unset', function(t) {
+  expect(t, 'set-size 1');
+  waiton(t, 'status', /worker count: *1/);
+
+  expect(t, 'env-get', 'No matching environment variables defined');
+  expect(t, 'env-get NOTSET', 'No matching environment variables defined');
+
+  expect(t, 'env-set FOO=bar BAR=foo', 'Environment updated');
+  expect(t, 'env-get', /FOO=bar/);
+  expect(t, 'env-get', /BAR=foo/);
+  expect(t, 'env-get FOO', /FOO=bar/);
+  expect(t, 'env-get NOTSET', 'No matching environment variables defined');
+
+  expect(t, 'env-unset FOO', 'Environment updated');
+  expect(t, 'env-get', /BAR=foo/);
+  expect(t, 'env-get FOO', 'No matching environment variables defined');
+});
+
+
+test('cpu start, stop', function(t) {
+  expect(t, 'set-size 1');
+  waiton(t, 'status', /worker count: *1/);
+
+  expect(t, 'cpu-start 0', /Profiler started/);
+  expect(t, 'cpu-stop 0', /CPU profile written.*node.0.cpuprofile/);
 
   if (process.platform === 'linux') {
-    expect('cpu-start 0 100', /Profiler started/);
-    expect('cpu-stop 0', /CPU profile written.*node.0.cpuprofile/);
+    expect(t, 'cpu-start 0 100', /Profiler started/);
+    expect(t, 'cpu-stop 0', /CPU profile written.*node.0.cpuprofile/);
   } else {
-    failon('cpu-start 0 100', /Profiler started/);
-    failon('cpu-stop 0', /Profiler stopped/);
+    failon(t, 'cpu-start 0 100', /Profiler started/);
+    failon(t, 'cpu-stop 0', /Profiler stopped/);
   }
+});
 
+test('objects start, stop', function(t) {
   if (process.env.STRONGLOOP_LICENSE) {
-    expect('objects-start 1');
-    expect('objects-stop 1');
+    expect(t, 'set-size 1');
+    waiton(t, 'status', /worker count: *1/);
+    expect(t, 'objects-start 1');
+    expect(t, 'objects-stop 1');
   } else {
-    console.error('SKIP objects-start/stop, no license');
+    t.skip('objects-start/stop, no license');
+    t.end();
   }
+});
 
-  expect('heap-snapshot 1 _heap');
-  assert.doesNotThrow(
-    function() {
-      fs.statSync('_heap.heapsnapshot')
-    },
-    '_heap.heapsnapshot should exist'
-  );
+test('heap snapshot', function(t) {
+  expect(t, 'set-size 1');
+  waiton(t, 'status', /worker count: *1/);
 
-  expect('shutdown');
+  expect(t, 'heap-snapshot 1 _heap');
+  t.test(function(t) {
+    t.doesNotThrow(
+      function() {
+        fs.statSync('_heap.heapsnapshot')
+      },
+      '_heap.heapsnapshot should exist'
+    );
+    t.end();
+  });
+});
 
-  pm.on('exit', done);
-}
-
-function done(code) {
-  assert.equal(code, 0);
-  helper.ok = true;
-}
+tap.test('shutdown', {timeout: 5000}, function(t) {
+  pm.on('exit', function(code, signal) {
+    console.log('shutdown caused exit:', signal || code);
+    t.equal(code, 0);
+    t.end();
+  });
+  expect(t, 'shutdown');
+});

--- a/test/test-server-status.js
+++ b/test/test-server-status.js
@@ -132,7 +132,7 @@ tap.test('worker status update', function(t) {
   }
 
   function checkWorkers(expect, next) {
-    m.ServiceProcess.find({serviceProcessId: 1}, function(err, processes) {
+    m.ServiceProcess.find({order: 'workerId ASC' }, function(err, processes) {
       debug('processes: %j', err || processes);
       debug('expect: %j', expect);
       debug('next: %j', next.name);


### PR DESCRIPTION
shelljs seems to sometimes fail to notice its child process exiting,
causing ephemeral test failures. The failures are semi-consistent once
they occur, but might not be seen. The sync execute also ate 100% CPU,
and after sufficient rewriting in tap, was not much more readable than
async.