### PR TITLE
Add HTTP auth support

### DIFF
--- a/bin/sl-pm-install.txt
+++ b/bin/sl-pm-install.txt
@@ -20,6 +20,11 @@ Options:
   --upstart VERSION   Specify the version of Upstart, 1.4 or 0.6
                       (default is 1.4)
   --systemd           Install as a systemd service, not an Upstart job.
+  --http-auth CREDS   Enable HTTP authentication using Basic auth,
+                      requiring the specified credentials for every
+                      request sent to the REST API where CREDS is
+                      given in the form of <user>:<pass>.
+
 
 OS Service support:
   The --systemd and --upstart VERSION options are mutually exclusive.

--- a/bin/sl-pm.txt
+++ b/bin/sl-pm.txt
@@ -10,6 +10,11 @@ Options:
   --no-control      Do not listen for local control messages.
 
 The process manager will be controllable via HTTP on the port specified. That
-port is also used for deployment with strong-deploy. It is also controllable
-using local domain sockets, which look like file paths, and the listen path
-can be changed or disabled.
+port is also used for deployment with strong-deploy. Basic authentication
+can be enabled for HTTP by setting the STRONGLOOP_PM_HTTP_AUTH environment
+variable to <user>:<pass> (eg. strong-pm:super-secret). This is the same format
+as used by the --http-auth option of pm-install.
+
+It is also controllable using local domain sockets, which look like file paths,
+and the listen path can be changed or disabled. These sockets do not support
+HTTP authentication.

--- a/bin/sl-pmctl.js
+++ b/bin/sl-pmctl.js
@@ -468,6 +468,9 @@ function download(endpoint, path, file, callback) {
   endpoint.pathname = path;
   location = url.format(endpoint);
 
+  // TODO: add support for Digest auth, which is probably easiest done by
+  //       switching to the request module
+  //       see test/test-pmctl-rest-digest-auth.js
   var get = http.get(location, function(res) {
     debug('http.get: %d', res.statusCode);
 

--- a/bin/sl-pmctl.txt
+++ b/bin/sl-pmctl.txt
@@ -16,7 +16,9 @@ in this order:
 
 An HTTP URL is mandatory for remote process managers, but can also be used on
 localhost. It must specify at least the process manager's listen port, such as
-`http://example.com:7654`.
+`http://example.com:7654`. If the process manager is using HTTP authentication
+then valid credentials must be set in the URL directly, such as
+`http://user-here:pass-here@example.com:7654`.
 
 Commands:
   status                  Report status, the default command.

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,64 @@
+var auth = require('http-auth');
+var crypto = require('crypto');
+var fmt = require('util').format;
+
+module.exports = makeAuthMiddleware;
+module.exports.parse = parseAuth;
+
+var authMethods = {
+  basic: makeBasicAuth,
+  digest: makeDigestAuth,
+  none: makeNoAuth,
+};
+
+function makeAuthMiddleware(pmAuthStr) {
+  var parts = parseAuth(pmAuthStr);
+  return authMethods[parts.scheme](parts.user, parts.realm, parts.pass);
+}
+
+var AUTH_REGEXP = /^(basic|digest):(.+):(.+)$/;
+function parseAuth(pmAuthStr) {
+  var parts = AUTH_REGEXP.exec(pmAuthStr) ||
+              AUTH_REGEXP.exec('basic:'+pmAuthStr);
+  var result = {
+    scheme: parts ? parts[1] : 'none',
+    user: parts && parts[2],
+    pass: parts && parts[3],
+    realm: 'strong-pm',
+  };
+  result.normalized = fmt('%s:%s:%s', result.scheme, result.user, result.pass);
+  return result;
+}
+
+function makeNoAuth() {
+  return function noop(req, res, next) {
+    next();
+  }
+}
+
+function makeBasicAuth(user, realm, pass) {
+  console.log('PM: enabling HTTP authentication (Basic)');
+  var basicAuth = auth.basic({ realm: realm }, checkCredentials);
+  return auth.connect(basicAuth);
+
+  function checkCredentials(maybeUser, maybePassword, cb) {
+    cb(maybeUser === user && maybePassword === pass);
+  }
+}
+
+function makeDigestAuth(user, realm, pass) {
+  console.log('PM: enabling HTTP authentication (Digest)');
+  var digest = md5(fmt('%s:%s:%s', user, realm, pass));
+  var digestAuth = auth.digest({ realm: realm }, checkDigest);
+  return auth.connect(digestAuth);
+
+  function checkDigest(maybeUser, cb) {
+    cb(maybeUser === user ? digest : null);
+  }
+}
+
+function md5(input) {
+  var hash = crypto.createHash('md5');
+  hash.update(input);
+  return hash.digest('hex');
+}

--- a/lib/install.js
+++ b/lib/install.js
@@ -9,6 +9,7 @@ var passwd = require('passwd-user');
 var path = require('path');
 var slServiceInstall = require('strong-service-install');
 var uidNumber = require('uid-number');
+var auth = require('./auth');
 
 module.exports = install;
 
@@ -37,6 +38,7 @@ function install(argv, callback) {
       'i:(upstart)', // -i unused, posix-getopt doesn't do long-only options
       's(systemd)',
       'm:(metrics)',
+      'a:(http-auth)',
     ].join(''),
     argv);
 
@@ -98,6 +100,9 @@ function install(argv, callback) {
       case 'm':
         jobConfig.pmSeedEnv.STRONGLOOP_METRICS = option.optarg;
         break;
+      case 'a':
+        jobConfig.env.STRONGLOOP_PM_HTTP_AUTH = auth.parse(option.optarg).normalized;
+        break;
       default:
         console.error('Invalid usage (near option \'%s\'), try `%s --help`.',
           option.optopt, $0);
@@ -133,6 +138,12 @@ function install(argv, callback) {
       jobConfig.upstart !== '0.6' && jobConfig.upstart !== '1.4') {
     console.error('Invalid usage (only upstart "0.6" and "1.4" supported)' +
                   ', see `%s --help`', $0);
+    return callback(Error('usage'));
+  }
+
+  if (jobConfig.env.STRONGLOOP_PM_HTTP_AUTH &&
+      auth.parse(jobConfig.env.STRONGLOOP_PM_HTTP_AUTH).scheme === 'none') {
+    console.error('Bad http-auth specification: %s', jobConfig.env.STRONGLOOP_PM_AUTH);
     return callback(Error('usage'));
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -17,6 +17,7 @@ var runner = require('./run');
 var setupPushReceiver = require('./receive').setupPushReceiver;
 var util = require('util');
 var compression = require('compression');
+var auth = require('./auth');
 
 // Extend base without modifying it.
 function extend(base, extra) {
@@ -34,6 +35,8 @@ function Server(originalCommand, configPath, baseDir, listenPort, controlPath) {
   this._app = loopback();
   this._envPath = path.resolve(this._baseDir, 'env.json');
   this._env = null;
+
+  this._app.use(auth(process.env.STRONGLOOP_PM_HTTP_AUTH));
 
   // Set up the /favicon.ico
   this._app.use(loopback.favicon());

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "debug": "^2.0.0",
     "errorhandler": "^1.2.0",
     "extsprintf": "^1.2.0",
+    "http-auth": "^2.2.5",
     "ini": "^1.2.1",
     "lodash": "^2.4.1",
     "loopback": "^2.4.0",

--- a/test/common.sh
+++ b/test/common.sh
@@ -50,6 +50,27 @@ function assert_file() {
   fi
 }
 
+function assert_not_file() {
+  local fname=$1
+  if test $# -gt 1; then
+    shift
+    found=$(grep -F -e "$*" $fname)
+    result=$?
+    if test $result -eq 0; then
+      fail "needle: '$*' in $fname"
+    else
+      ok "needle: '$*' NOT in $fname"
+    fi
+  else
+    report="file exists: $fname"
+    if test -f $fname; then
+      fail "$report"
+    else
+      ok "$report"
+    fi
+  fi
+}
+
 function assert_report() {
   exit $fails
 }

--- a/test/helper-async.js
+++ b/test/helper-async.js
@@ -1,0 +1,92 @@
+var assert = require('assert');
+var path = require('path');
+var cp = require('child_process');
+var childctl = require('strong-control-channel/process');
+var defaults = require('lodash').defaults;
+
+require('shelljs/global');
+
+exports.reset = reset;
+exports.pm = pm;
+
+function reset(callback) {
+  console.log('working dir for %s is %s', process.argv[1], process.cwd());
+
+  // Enter test sandbox app
+  cd(path.resolve(__dirname, 'app'));
+
+  // Make sure we're working in our sandbox
+  assert.equal(package().name, 'test-app', 'cwd is test-app');
+
+  rm('-rf', '../receive-base');
+  rm('-rf', '.git', '.strong-pm');
+  ex('git clean -f -d -x .');
+  assert(!test('-e', 'node_modules'));
+  ex('git init');
+  ex('git add .');
+  ex('git commit --author="sl-pm-test <nobody@strongloop.com>" -m initial');
+  ex('sl-build --install --commit');
+
+  assert(!test('-e', 'node_modules/debug'), 'dev dep not installed');
+  assert(test('-e', 'node_modules/buffertools'), 'prod dep installed');
+  assert(!test('-e', 'node_modules/buffertools/build'), 'addons not built');
+  assert(which('sl-build'), 'sl-build not in path');
+
+  console.log('test/app built succesfully');
+
+  if (callback) {
+    setImmediate(callback);
+  }
+
+  function ex(cmd, async) {
+    console.log('exec `%s`', cmd);
+    return exec(cmd, async);
+  }
+
+  function package() {
+    return require(path.resolve(pwd(),'package.json'));
+  }
+}
+
+var pmcli = require.resolve('../bin/sl-pm.js');
+
+function pm(args, env, callback) {
+  args = args || [];
+  env = env || {};
+
+  if (typeof env === 'function' && !callback) {
+    callback = env;
+    env = {};
+  }
+
+  // Listened on zero to avoid port conflicts, search for actual port.
+  args.push('--listen=0');
+
+  console.log('pmcli:', pmcli, args);
+
+  var pm = cp.spawn(pmcli, args, {
+    stdio: ['ignore', process.stdout, process.stderr, 'ipc'],
+    env: defaults(env, process.env),
+  });
+
+  pm.on('error', function(er) {
+    assert.ifError(er);
+  });
+
+  if (callback) {
+    pm.on('listening', callback);
+  }
+
+  // Used by PM to signal its controller that it is listening
+  pm.ctl = childctl.attach(onReceive, pm);
+
+  return pm;
+
+  function onReceive(req, cb) {
+    if (req.cmd && req.cmd === 'listening') {
+      console.log('Listening port: %s', req.port);
+      pm.emit('listening', req.port);
+    }
+    return cb();
+  }
+}

--- a/test/test-auth.js
+++ b/test/test-auth.js
@@ -1,0 +1,15 @@
+var tap = require('tap');
+
+var auth = require('../lib/auth');
+
+tap.test('auth parsing', function(t) {
+  var io = {
+    'basic:user:pass': 'basic:user:pass',
+    'digest:user:pass': 'digest:user:pass',
+    'user:pass': 'basic:user:pass',
+  };
+  for (var input in io) {
+    t.equal(auth.parse(input).normalized, io[input], 'normalizes ' + io);
+  }
+  t.end();
+});

--- a/test/test-git-push.js
+++ b/test/test-git-push.js
@@ -1,0 +1,85 @@
+var cp = require('child_process');
+var tap = require('tap');
+var fmt = require('util').format;
+var helper = require('./helper-async');
+
+tap.test('without auth', function(t) {
+  helper.reset();
+  var pm = helper.pm([], { STRONGLOOP_PM_HTTP_AUTH: '' });
+  pm.on('listening', function(port) {
+    var pmurl = fmt('http://127.0.0.1:%d/default', port);
+    console.log('pmurl: %s', pmurl);
+
+    t.assert(port, 'pm started on port ' + port);
+
+    cp.exec(fmt('git push %s master:master', pmurl), function(er) {
+      t.ifError(er, 'git push succeeds when auth not required');
+      pm.kill('SIGTERM');
+    });
+  });
+  pm.on('exit', function(code, signal) {
+    t.equal(signal, 'SIGTERM', 'killed by us');
+    t.end();
+  });
+});
+
+tap.test('with basic auth and valid credentials', function(t) {
+  helper.reset();
+  var pm = helper.pm([], { STRONGLOOP_PM_HTTP_AUTH: 'basic:user:pass' });
+  pm.on('listening', function(port) {
+    var pmurl = fmt('http://user:pass@127.0.0.1:%d/default', port);
+    console.log('pmurl: %s', pmurl);
+
+    t.assert(port, 'pm started on port ' + port);
+
+    cp.exec(fmt('git push %s master:master', pmurl), function(er) {
+      t.ifError(er, 'git push succeeds with basic auth');
+      pm.kill('SIGTERM');
+    });
+  });
+  pm.on('exit', function(code, signal) {
+    t.equal(signal, 'SIGTERM', 'killed by us');
+    t.end();
+  });
+});
+
+tap.test('with digest auth and valid credentials', function(t) {
+  helper.reset();
+  var pm = helper.pm([], { STRONGLOOP_PM_HTTP_AUTH: 'digest:user:pass' });
+  pm.on('listening', function(port) {
+    var pmurl = fmt('http://user:pass@127.0.0.1:%d/default', port);
+    console.log('pmurl: %s', pmurl);
+
+    t.assert(port, 'pm started on port ' + port);
+
+    cp.exec(fmt('git push %s master:master', pmurl), function(er) {
+      t.ifError(er, 'git push succeeds with digest auth');
+      pm.kill('SIGTERM');
+    });
+  });
+  pm.on('exit', function(code, signal) {
+    t.equal(signal, 'SIGTERM', 'killed by us');
+    t.end();
+  });
+});
+
+
+tap.test('with auth and invalid credentials', function(t) {
+  helper.reset();
+  var pm = helper.pm([], { STRONGLOOP_PM_HTTP_AUTH: 'basic:user:pass' });
+  pm.on('listening', function(port) {
+    var pmurl = fmt('http://baduser:badpass@127.0.0.1:%d/default', port);
+    console.log('pmurl: %s', pmurl);
+
+    t.assert(port, 'pm started on port ' + port);
+
+    cp.exec(fmt('git push %s master:master', pmurl), function(er) {
+      t.assert(er, 'git push fails with bad credentials');
+      pm.kill('SIGTERM');
+    });
+  });
+  pm.on('exit', function(code, signal) {
+    t.equal(signal, 'SIGTERM', 'killed by us');
+    t.end();
+  });
+});

--- a/test/test-pmctl-local.js
+++ b/test/test-pmctl-local.js
@@ -22,7 +22,9 @@ function setup(t) {
       return t.end();
     }
     _pm = manager(function(_port) {
-      var pmurl = util.format('http://127.0.0.1:%d/default', _port);
+      var auth = process.env.TEST_STRONGLOOP_PM_HTTP_AUTH || '';
+      auth += auth.length > 0 ? '@' : '';
+      var pmurl = util.format('http://%s127.0.0.1:%d/default', auth, _port);
       console.log('pmurl: %s', pmurl);
 
       cp.exec(util.format('git push %s master:master', pmurl), function(er) {
@@ -151,7 +153,10 @@ function manager(callback) {
     console.log('Listening port: %s', port);
 
     if (process.env.STRONGLOOP_PM) {
-      process.env.STRONGLOOP_PM = 'http://localhost:' + port;
+      var auth = process.env.TEST_STRONGLOOP_PM_HTTP_AUTH || '';
+      auth += auth.length > 0 ? '@' : '';
+      process.env.STRONGLOOP_PM = util.format('http://%s127.0.0.1:%d/',
+                                              auth, port);
     }
 
     callback(port);

--- a/test/test-pmctl-rest-basic-auth.js
+++ b/test/test-pmctl-rest-basic-auth.js
@@ -1,0 +1,10 @@
+// Run pmctl tests against the API
+process.env.STRONGLOOP_PM = 'x'; // Will be filled in with actual pm port/url
+
+// tell pm server to require auth (Basic method)
+process.env.STRONGLOOP_PM_HTTP_AUTH = 'basic:testuser:testpassword';
+
+// tell pm client to use credentials
+process.env.TEST_STRONGLOOP_PM_HTTP_AUTH = 'testuser:testpassword';
+
+require('./test-pmctl-local');

--- a/test/test-pmctl-rest-digest-auth.js
+++ b/test/test-pmctl-rest-digest-auth.js
@@ -1,0 +1,6 @@
+console.log('not ok # TODO implement Digest auth support in pmctl');
+
+// TODO: In order to use Digest auth across the board, the pmctl CLI must
+// support Digest auth for all actions. Currently actions that involve
+// downloading a file make use of http.request, which does not support Digest
+// auth.


### PR DESCRIPTION
Depends on:
 * release of strong-fork-pushover that includes https://github.com/strongloop-forks/strong-fork-pushover/commit/6d673fbc4f86112e9ca33bf56cacd1083ee364b7
 * https://github.com/strongloop/strong-remoting/pull/163

TODO:
 * ~~add support for Digest auth requests to `pmctl` for downloading snapshots (`http.get` doesn't cut it, probably need something like `request`)~~
 * [x] Add comments about the state of Digest auth support in the code and document it as unsupported in the usage text.
 * [x] Add CLI options for setting `SL_PM_AUTH` during `sl-pm-install`

Closes #99