### PR TITLE
Use process pid when filtering for model updates

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -209,6 +209,7 @@ Server.prototype._onWorkerExit = function _onWorkerExit(pInfo, callback) {
       where: {
         serviceInstanceId: 1,
         workerId: +pInfo.id,
+        pid: pInfo.pid,
       }
     }),
     updateProcess,
@@ -269,7 +270,7 @@ Server.prototype._onMetrics = function _onMetrics(req, callback) {
     Process.findOne(q, function(err, proc) {
       assert.ifError(err);
       if (!proc) {
-        console.error('Ignoring metrics for unknown worker: %d', wid);
+        debug('Ignoring metrics for unknown worker: %d', wid);
         // Metrics can show up after process death, or perhaps even before
         // supervisor knows they have forked. The timing is a bit
         // uncertain, don't rely on it.
@@ -352,11 +353,13 @@ Server.prototype._onProfileStatusUpdate =
     async.waterfall([
       ServiceProcess.findOne.bind(ServiceProcess, {
         serviceInstanceId: 1,
-        workerId: wInfo.id
+        workerId: wInfo.id,
+        pid: wInfo.pid,
       }),
       updateProcessStatus
-    ], function(err){
+    ], function(err, proc){
       assert.ifError(err);
+      debug('Process entry updated: %j', proc);
       if (callback) callback(err);
     });
 


### PR DESCRIPTION
Worker ID is no longer unique after doing a stop/start as the supervisor
restarts the worker count at 0. So, we need to use the PID when finding
models to update for stop/profile events.

Connect to strongloop/strong-arc#978