### PR TITLE
Expose "ExpressUsageRecord"

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -294,6 +294,49 @@ Server.prototype._onMetrics = function _onMetrics(req, callback) {
   }
 };
 
+Server.prototype._onExpressUsageRecord = function(req, callback) {
+  debug('express usage record: %j', req.record);
+  var Process = this._app.models.ServiceProcess;
+  var ExpressUsageRecord = this._app.models.ExpressUsageRecord;
+  var record = req.record;
+  var pid = +record.process.pid;
+
+  var q = {where: {
+    serviceInstanceId: 1,
+    pid: pid,
+    stopTime: null
+  }};
+
+  Process.findOne(q, function(err, proc) {
+    assert.ifError(err);
+    if (!proc) {
+      debug('Ignoring metrics for unknown worker pid: %d', pid);
+      return deleteOld();
+    }
+
+    var usageRecord = {
+      processId: pid,
+      workerId: proc.workerId,
+      timestamp: record.timestamp,
+      usage: record
+    };
+
+    ExpressUsageRecord.create(usageRecord, function(err) {
+      assert.ifError(err);
+      deleteOld();
+    });
+  });
+
+  function deleteOld() {
+    var now = new Date().getTime();
+    var where = { timestamp: { lt: now - 5 * 60 * 1000 } };
+    ExpressUsageRecord.destroyAll(where, function(err) {
+      assert.ifError(err);
+      callback();
+    });
+  }
+};
+
 Server.prototype._onRunnerRequest = function _onRunnerRequest(req, callback) {
   debug('Notification: %j', req);
   // Relay notifications to parent process if present
@@ -337,6 +380,8 @@ Server.prototype._onRunnerRequest = function _onRunnerRequest(req, callback) {
     case 'cpu-profiling':
     case 'heap-snapshot':
       return this._onProfileStatusUpdate(req, callback);
+    case 'express:usage-record':
+      return this._onExpressUsageRecord(req, callback);
     default: {
       debug('runner unknown request: %j', req);
       if (callback) callback();

--- a/lib/server/model-config.json
+++ b/lib/server/model-config.json
@@ -53,6 +53,10 @@
     "dataSource": "db",
     "public": false
   },
+  "ExpressUsageRecord": {
+    "dataSource": "db",
+    "public": true
+  },
   "InstanceAction": {
     "dataSource": "db",
     "public": false

--- a/test/test-server-express-usage-record.js
+++ b/test/test-server-express-usage-record.js
@@ -1,0 +1,98 @@
+var Server = require('../lib/server');
+var assert = require('assert');
+var async = require('async');
+var debug = require('debug')('strong-pm:test');
+var path = require('path');
+var runner = require('../lib/run');
+var tap = require('tap');
+var events = require('events');
+var util = require('util');
+
+var BASE = path.resolve(__dirname, '.strong-pm');
+
+function MockCurrent() {
+  this.child = {
+    pid: 59312
+  };
+}
+util.inherits(MockCurrent, events.EventEmitter);
+
+MockCurrent.prototype.request = function request(req, cb) {
+  if (req.cmd === 'status') {
+    cb({ master: { setSize: 1 } });
+  }
+  if (req.cmd === 'npm-ls') {
+    cb({});
+  }
+}
+
+var WORKER_PID = 1001;
+
+var USAGE_RECORD = {
+  timestamp: Date.now(),
+  client: { address: "::1" },
+  request: { method: "GET", url: "/" },
+  response: { status: 404, duration: 6 },
+  process: { pid: WORKER_PID },
+  data: { custom: 'value' }
+};
+
+tap.test('ExpressUsageRecord', function(t) {
+  var s = new Server('pm', '_base', 1234, null);
+  var m = s._app.models;
+  var commit = {hash: 'hash1', dir: 'dir1'};
+
+  runner._mockCurrent = new MockCurrent();
+  runner._mockCurrent.commit = commit;
+  runner.current = function() {
+    return runner._mockCurrent;
+  }
+
+  s._isStarted = true; // Make server think its running.
+
+  async.series([
+    function loadModels(next) {
+      s._loadModels(next);
+    },
+    function emitRunning(next) {
+      // mock started event from runner
+      s._onMasterStart({
+        cmd: 'started',
+        appName: 'test-app',
+        agentVersion: '1.0.0',
+        pid: 1234
+      }, next);
+    },
+    function emitFork(next) {
+      // mock "fork" event from runner
+      runner.emit('request', { cmd: 'fork', id: 1, pid: WORKER_PID }, next);
+    },
+    function emitUsageRecord(next) {
+      var message = { cmd: 'express:usage-record', record: USAGE_RECORD };
+      runner.emit('request', message, next);
+    },
+    function emitTooOldUsageRecord(next) {
+      var rec = util._extend({}, USAGE_RECORD);
+      rec.timestamp = Date.now() - 24 * 60 * 1000;
+      var message = { cmd: 'express:usage-record', record: rec };
+      runner.emit('request', message, next);
+    },
+    function checkUsageRecord(next) {
+      m.ExpressUsageRecord.find(function(err, list) {
+        if (err) return next(err);
+        assert.equal(list.length, 1);
+
+        var data = list[0].toObject();
+
+        assert.ok(!!data.processId, 'Process ID should be set');
+        assert.equal(data.workerId, 1);
+        assert.equal(+data.timestamp, +USAGE_RECORD.timestamp);
+        assert.deepEqual(data.usage, USAGE_RECORD);
+        next();
+      });
+    }
+  ], function(err) {
+    if (err) throw err;
+    t.end();
+  });
+});


### PR DESCRIPTION
When the supervised express-base application has strong-express-metrics
configured, strong-agent and strong-supervisor will forward usage
records all the way to strong-pm.

This commit adds a listener that collects these usage record events
and exposes the last 5 minutes of the data via a REST API.

```
GET /api/ExpressUsageRecords
[{
  "id": 1,
  "processId": 1,
  "workerId": 1,
  "timestamp": "2015-02-18T12:24:10.186Z",
  "usage": {
    "data": {},
    "process": {
      "pid": 19801
    },
    "response": {
      "duration": 5,
      "status": 404
    },
    "request": {
      "url": "/",
      "method": "GET"
    },
    "client": {
      "address": "::1"
    },
    "timestamp": "2015-02-18T12:24:10.186Z"
  }
}, {
  "id": 2,
  "processId": 2,
  "workerId": 2,
  "timestamp": "2015-02-18T12:24:33.625Z",
  "usage": {
    "data": {},
    "process": {
      "pid": 19805
    },
    "response": {
      "duration": 15,
      "status": 404
    },
    "request": {
      "url": "/",
      "method": "GET"
    },
    "client": {
      "address": "::1"
    },
    "timestamp": "2015-02-18T12:24:33.625Z"
  }
  // etc
}]
```

Close strongloop-internal/scrum-loopback#126
Related (and already landed) PRs: https://github.com/strongloop/strong-supervisor/pull/87, https://github.com/strongloop/strongops/pull/251

/to @sam-github @kraman please review

Connect to strongloop/strong-pm#125