### PR TITLE
Use /var/lib/strong-pm instead of /var/lib/strong-pm/.strong-pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ Options:
   -v,--version        Print version and exit.
   -m,--metrics STATS  Specify --metrics option for supervisor running
                       deployed applications.
-  -b,--base BASE      Base directory to work in (default is .strong-pm).
+  -b,--base BASE      Base directory to work in (default is $HOME of
+                      the user that manager is run as, see --user).
   -e,--set-env K=V... Initial application environment variables. If
                       setting multiple variables they must be quoted
                       into a single argument: "K1=V1 K2=V2 K3=V3".

--- a/bin/sl-pm-install.txt
+++ b/bin/sl-pm-install.txt
@@ -5,7 +5,8 @@ Options:
   -v,--version        Print version and exit.
   -m,--metrics STATS  Specify --metrics option for supervisor running
                       deployed applications.
-  -b,--base BASE      Base directory to work in (default is .strong-pm).
+  -b,--base BASE      Base directory to work in (default is $HOME of
+                      the user that manager is run as, see --user).
   -e,--set-env K=V... Initial application environment variables. If
                       setting multiple variables they must be quoted
                       into a single argument: "K1=V1 K2=V2 K3=V3".

--- a/lib/install.js
+++ b/lib/install.js
@@ -145,6 +145,7 @@ function install(argv, callback) {
 
   var steps = [
     ensureUser, fillInGroup, fillInHome,
+    resolveIds,
     setCommand, ensureBaseDir,
     prepareSeedEnvironment,
     writeSeedEnvironment,
@@ -244,6 +245,19 @@ function fillInHome(options, callback) {
   });
 }
 
+function resolveIds(options, callback) {
+  uidNumber(options.user, options.group, function(err, uid, gid) {
+    if (err) {
+      console.error('Error getting numeric uid/gid of %s/%s: %s',
+                    options.user, options.group, err.message);
+      return callback(err);
+    }
+    options._userId = uid;
+    options._groupId = gid;
+    callback();
+  });
+}
+
 function setCommand(options, callback) {
   options.name = 'strong-pm';
   options.pmBaseDir = path.resolve(options.cwd, options.pmBaseDir);
@@ -276,29 +290,22 @@ function ensureOwner(options, callback) {
     return setImmediate(callback);
   }
   console.error('ensuring owner: ', options.pmBaseDir);
-  uidNumber(options.user, options.group, function(err, uid, gid) {
+  subPaths(options.pmBaseDir, function(err, paths) {
     if (err) {
-      console.error('Error getting numeric uid/gid of %s/%s: %s',
-                    options.user, options.group, err.message);
       return callback(err);
+    } else {
+      return async.each(paths, chown, callback);
     }
-    subPaths(options.pmBaseDir, function(err, paths) {
-      if (err) {
-        return callback(err);
-      } else {
-        return async.each(paths, chown, callback);
-      }
 
-      function chown(path, next) {
-        fs.chown(path, uid, gid, function(err) {
-          if (err) {
-            console.error('Error setting ownership of base directory %s: %s',
-                          path, err.message);
-          }
-          next(err);
-        });
-      }
-    });
+    function chown(path, next) {
+      fs.chown(path, options._userId, options._groupId, function(err) {
+        if (err) {
+          console.error('Error setting ownership of base directory %s: %s',
+                        path, err.message);
+        }
+        next(err);
+      });
+    }
   });
 
   function subPaths(dir, callback) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -46,7 +46,7 @@ function install(argv, callback) {
 
   var jobConfig = {
     user: 'strong-pm',
-    pmBaseDir: '.strong-pm', // this should be options.cwd from fillInHome
+    pmBaseDir: null, // defaults to options.cwd in fillInHome
     pmPort: 0, // invalid by default
     dryRun: false,
     jobFile: null, // strong-service-install provides an init-specific default
@@ -238,6 +238,7 @@ function fillInHome(options, callback) {
       options.env = options.env || {};
       options.env.HOME = user.homedir;
       options.cwd = user.homedir;
+      options.pmBaseDir = options.pmBaseDir || options.cwd;
     }
     callback(err);
   });

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,5 +1,6 @@
 var async = require('async');
 var child_process = require('child_process');
+var chownr = require('chownr');
 var debug = require('debug')('strong-pm:install');
 var Environment = require('./env');
 var fs = require('fs');
@@ -290,42 +291,14 @@ function ensureOwner(options, callback) {
     return setImmediate(callback);
   }
   console.error('ensuring owner: ', options.pmBaseDir);
-  subPaths(options.pmBaseDir, function(err, paths) {
+  chownr(options.pmBaseDir, options._userId, options._groupId, function(err) {
     if (err) {
-      return callback(err);
-    } else {
-      return async.each(paths, chown, callback);
+      console.error('Error setting ownership of base directory %s: %s',
+                    options.pmBaseDir, err.message);
     }
-
-    function chown(path, next) {
-      fs.chown(path, options._userId, options._groupId, function(err) {
-        if (err) {
-          console.error('Error setting ownership of base directory %s: %s',
-                        path, err.message);
-        }
-        next(err);
-      });
-    }
+    callback(err);
   });
 
-  function subPaths(dir, callback) {
-    var cmd = '/usr/bin/find';
-    var args = [ dir.replace(/\/+$/, '') ];
-    child_process.execFile(cmd, args, function(err, stdout, stderr) {
-      if (err) {
-        console.error('Error walking path %s:\n%s\n%s',
-                      dir, stdout, stderr);
-      }
-      var paths = stdout.split(/\n/)
-                        // .map(function(p) {
-                        //   return path.join(dir, p);
-                        // });
-                        .filter(function(p) {
-                          return p.length > 0;
-                        });
-      callback(err, paths);
-    });
-  }
 }
 
 function prepareSeedEnvironment(options, callback) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -57,6 +57,7 @@ function install(argv, callback) {
     env: {},
     pmEnv: '',
     pmSeedEnv: {},
+    _touched: [], // not a real config, used for recording paths to chown
   };
 
   while ((option = parser.getopt()) !== undefined) {
@@ -281,24 +282,28 @@ function ensureBaseDir(options, callback) {
     if (err) {
       console.error('Error creating base directory %s: %s', made, err.message);
     }
+    if (made) {
+      options._touched.push(made);
+    }
     callback(err);
   });
 }
 
 function ensureOwner(options, callback) {
   if (options.dryRun) {
-    console.log('Would chown ', options.pmBaseDir);
+    console.log('Would chown ', [options.pmBaseDir].concat(options._touched));
     return setImmediate(callback);
   }
-  console.error('ensuring owner: ', options.pmBaseDir);
-  chownr(options.pmBaseDir, options._userId, options._groupId, function(err) {
-    if (err) {
-      console.error('Error setting ownership of base directory %s: %s',
-                    options.pmBaseDir, err.message);
-    }
-    callback(err);
-  });
+  console.error('ensuring owner: ', [options.pmBaseDir].concat(options._touched));
+  var tasks = [
+    // non-recusive for basedir since it may be an existing $HOME
+    fs.chown.bind(fs, options.pmBaseDir, options._userId, options._groupId)
+  ].concat(options._touched.map(function(path) {
+    // recursive for everything else because we can
+    return chownr.bind(null, path, options._userId, options._groupId);
+  }));
 
+  return async.parallel(tasks, callback);
 }
 
 function prepareSeedEnvironment(options, callback) {
@@ -338,6 +343,7 @@ function writeSeedEnvironment(options, callback) {
       console.log('Would seed environment with: %j', env);
       return cb();
     } else {
+      options._touched.push(path);
       store.save(cb);
     }
   }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "bl": "^0.9.4",
+    "chownr": "0.0.1",
     "compression": "^1.1.0",
     "concat-stream": "^1.4.6",
     "debug": "^2.0.0",

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -68,7 +68,7 @@ assert_file $TMP/deeply/nested/sl-pm/env.json '"LESS":"more"'
 # Should fail to overwrite existing file
 assert_exit 1 $CMD --port 7777 --user `id -un` \
                    --job-file $TMP/upstart.conf \
-                   --base $TMP/deeply/nested/sl-pm 2>&1 \
+                   --base $TMP/deeply/nested/sl-pm 2>&1
 
 # Should overwrite upstart job when --force specified
 assert_exit 0 $CMD --port 7777 \
@@ -81,6 +81,14 @@ assert_exit 0 $CMD --port 7777 \
 # Should add auth to config, treating "myuser:mypass" as implied Basic auth
 assert_file $TMP/upstart.conf "STRONGLOOP_PM_HTTP_AUTH=basic:myuser:mypass"
 
+# Should create an upstart job at the specified path
+assert_exit 0 $CMD --port 7777 \
+                   --job-file $TMP/upstart-with-basedir.conf \
+                   --user `id -un`
+
+# Should not be a subdir of $HOME, should be exactly $HOME
+assert_not_file $TMP/upstart-with-basedir.conf "--base $HOME/"
+assert_file $TMP/upstart-with-basedir.conf "--base $HOME"
 
 unset SL_PM_INSTALL_IGNORE_PLATFORM
 assert_report


### PR DESCRIPTION
Change the default basedir in pm-install to something more practical. There is no reason to create the additional .strong-pm directory inside a dedicated strong-pm root directory.

Connected to strongloop-internal/scrum-nodeops#90