### PR TITLE
Add support for pmctl over http over ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ localhost. It must specify at least the process manager's listen port, such as
 then valid credentials must be set in the URL directly, such as
 `http://user-here:pass-here@example.com:7654`.
 
+When using an HTTP URL, it can optionally be tunneled over ssh by changing the
+protocol to `http+ssh://`. The ssh username will default to your current user
+and authentication defaults to using your current ssh-agent. The username can be
+overridden by setting an `SSH_USER` environment variable. The authentication can
+be overridden to use an existing private key instead of an agent by setting the
+`SSH_KEY` environment variable to the path of the private key to be used.
+
 Commands:
   status                  Report status, the default command.
   shutdown                Stop the process manager.
@@ -248,6 +255,9 @@ Commands:
         the application is hard restarted with the new environment after change
         (either set or unset).
 
+  log-dump [--follow]     Empty the log buffer, dumping the contents to stdout.
+                          If --follow is given the log buffer is continuously
+                          dumped to stdout.
+
 Worker `ID` is either a node cluster worker ID, or an operating system process
 ID. The special worker ID `0` can be used to identify the master.
-```

--- a/bin/sl-pmctl.txt
+++ b/bin/sl-pmctl.txt
@@ -20,6 +20,13 @@ localhost. It must specify at least the process manager's listen port, such as
 then valid credentials must be set in the URL directly, such as
 `http://user-here:pass-here@example.com:7654`.
 
+When using an HTTP URL, it can optionally be tunneled over ssh by changing the
+protocol to `http+ssh://`. The ssh username will default to your current user
+and authentication defaults to using your current ssh-agent. The username can be
+overridden by setting an `SSH_USER` environment variable. The authentication can
+be overridden to use an existing private key instead of an agent by setting the
+`SSH_KEY` environment variable to the path of the private key to be used.
+
 Commands:
   status                  Report status, the default command.
   shutdown                Stop the process manager.

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "strong-npm-ls": "^1.0.0",
     "strong-service-install": "^1.1.0",
     "strong-supervisor": "^1.4.0",
+    "strong-tunnel": "^1.1.1",
     "tar": "^1.0.0",
     "uid-number": "0.0.5"
   }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "semver": "^4.1.0",
     "shelljs": "^0.3.0",
     "strong-build": "^1.0.0",
-    "tap": "git://github.com/strongloop-forks/node-tap#production"
+    "tap": "^0.6.0"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/test/helper-async.js
+++ b/test/helper-async.js
@@ -240,7 +240,9 @@ function failon(t, cmd, pattern, next) {
 function pmctl(cmd, callback) {
   var cli = require.resolve('../bin/sl-pmctl.js');
   var args = [cli].concat(cmd);
-  return cp.execFile(process.execPath, args, {env: { STRONGLOOP_PM: '' }}, function(er, stdout, stderr) {
+  var env = JSON.parse(JSON.stringify(process.env));
+  env.STRONGLOOP_PM = '';
+  return cp.execFile(process.execPath, args, {env: env}, function(er, stdout, stderr) {
     var out = {
       out: stdout.trim(),
       err: stderr.trim(),

--- a/test/test-pmctl-ssh2.js
+++ b/test/test-pmctl-ssh2.js
@@ -1,0 +1,17 @@
+process.env.STRONGLOOP_CLUSTER = 1;
+
+var fmt = require('util').format;
+var helper = require('./helper-async');
+var tap = require('tap');
+
+tap.test('pmctl over ssh', function(t) {
+  helper.pmWithApp([], { STRONGLOOP_PM: 'x' }, function(pm) {
+    var sshPath = fmt('http+ssh://127.0.0.1:%d/api', pm.port);
+    var pmctl = helper.pmctlWithCtl(sshPath);
+    t = helper.queued(t);
+    t.waiton(pmctl('status'), /worker count: *1/);
+    t.expect(pmctl('log-dump'), /.+ worker:1 pid \d+ listening on \d+/);
+    t.expect(pmctl('ls'), /buffertools@/);
+    t.shutdown(pm);
+  });
+});


### PR DESCRIPTION
Allows `-C/--control` to specify a `http+ssh://host:port/` URL. The ssh connection is made using the current local username and assumes an ssh-agent is running and $SSH_AUTH_SOCK is set. Internally, a local TCP proxy is created which forwards requests over the created ssh connection.

Depends on strongloop/strong-tunnel#1
Connected to #98