### PR TITLE
Fix exclusive tmpdir

### DIFF
--- a/lib/pack-receiver.js
+++ b/lib/pack-receiver.js
@@ -91,7 +91,7 @@ PackReceiver.prototype.handle = function (req, res) {
   mkdirp(tmpDirPath, {}, function(err, made) {
     if (err) {
       console.log('Unable to create temporary dir: %s (%s)', made, err);
-      this.sendError(res, 'Internal error');
+      that.sendError(res, 'Internal error');
       return;
     }
     var tarballPath = path.join(tmpDirPath, 'application.tgz');

--- a/lib/pack-receiver.js
+++ b/lib/pack-receiver.js
@@ -1,5 +1,6 @@
 var cicadaCommit = require('strong-fork-cicada/lib/commit');
 var crypto = require('crypto');
+var fmt = require('util').format;
 var fs = require('fs');
 var mkdirp = require('mkdirp');
 var os = require('os');
@@ -87,7 +88,8 @@ PackReceiver.prototype.getTarballHash = function (req, res, tarballPath) {
 
 PackReceiver.prototype.handle = function (req, res) {
   var that = this;
-  var tmpDirPath = path.join(os.tmpdir(), 'strong-pm', Date.now().toString());
+  var tmpDir = fmt('strong-pm-%d-%d', process.pid, Date.now());
+  var tmpDirPath = path.join(os.tmpdir(), tmpDir);
   mkdirp(tmpDirPath, {}, function(err, made) {
     if (err) {
       console.log('Unable to create temporary dir: %s (%s)', made, err);


### PR DESCRIPTION
 * fix broken `sendError()` in tgz pack receiver
 * fix exclusive tmpdir assumption in tgz pack receiver

@chandadharap @cgole @sam-github @kraman this PR is against the 1.x branch so that we can publish a 1.7.3 patch release without waiting for the big 2.0.0 release.

As discovered in http://stackoverflow.com/questions/28759991/strongloop-deployment