### PR TITLE
Replace env pmctl with mesh model based API

### DIFF
--- a/lib/ctl.js
+++ b/lib/ctl.js
@@ -48,10 +48,7 @@ function onCtlRequest(options, req, callback) {
       break;
 
     case 'env-set':
-      app.updateEnv(req.env);
-      // if the env hasn't actually changed this is a soft reload
-      // if the env has changed, it does a hard restart
-      rsp.message = 'Updated environment, restarting app';
+      rsp = setEnv(app, req.env, callback);
       break;
 
     case 'env-get':
@@ -184,6 +181,31 @@ function restart(app, style, current, rsp, callback) {
       current.start();
       rsp.message += ', restarting...';
       return callback(rsp);
+    });
+  });
+}
+
+function setEnv(app, env, callback) {
+  // if the env hasn't actually changed this is a soft reload
+  // if the env has changed, it does a hard restart
+  var Service = app._app.models.ServerService;
+  Service.findById(1, function(err, svc) {
+    if (err) {
+      return callback({error: err});
+    }
+    var k;
+    for (k in env) {
+      if (env[k] === null) {
+        delete svc.env[k];
+      } else {
+        svc.env[k] = env[k];
+      }
+    }
+    svc.save(function(err, res) {
+      if (err) {
+        return callback({error: err});
+      }
+      callback({message: 'Updated environment, restarting app'});
     });
   });
 }

--- a/lib/env.js
+++ b/lib/env.js
@@ -48,3 +48,13 @@ Environment.prototype.all = function all() {
 Environment.prototype.unset = function unset(name) {
   delete this.env[name];
 };
+
+Environment.prototype.apply = function apply(newEnv) {
+  for (var k in newEnv) {
+    if (newEnv[k] === null) {
+      this.unset(k);
+    } else {
+      this.set(k, newEnv[k]);
+    }
+  }
+};

--- a/lib/install.js
+++ b/lib/install.js
@@ -297,8 +297,7 @@ function ensureOwner(options, callback) {
     console.log('Would chown ', [options.pmBaseDir].concat(options._touched));
     return setImmediate(callback);
   }
-  console.error(
-    'ensuring owner: ', [options.pmBaseDir].concat(options._touched));
+  debug('ensuring owner: ', [options.pmBaseDir].concat(options._touched));
   var tasks = [
     // non-recusive for basedir since it may be an existing $HOME
     fs.chown.bind(fs, options.pmBaseDir, options._userId, options._groupId)

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,7 +31,7 @@ function Server(originalCommand, baseDir, listenPort, controlPath) {
   this._listenPort = listenPort;
   this._controlPath = controlPath;
   this._envPath = path.resolve(this._baseDir, 'env.json');
-  this._env = null;
+  this._env = new Environment(this._envPath);
 
   // The express app which the rest of the middleware (mesh-models, deploy
   // receive hooks etc.) are mounted on.
@@ -226,6 +226,7 @@ Server.prototype._loadModels = function _loadModels(callback) {
     id: 1,
     name: 'default',
     _groups: [group],
+    env: this.env(),
   });
 
   var instance = new Instance({
@@ -258,7 +259,7 @@ Server.prototype.start = function start(cb) {
     ctlListen,
     parentIpcListen,
     loadModels,
-    loadEnv,
+    saveEnv,
     runCurrent,
     emitListeningSignal,
   ], done);
@@ -334,9 +335,8 @@ Server.prototype.start = function start(cb) {
     self._loadModels(callback);
   }
 
-  function loadEnv(callback) {
-    debug('loading environment');
-    self._env = new Environment(self._envPath);
+  function saveEnv(callback) {
+    debug('persisting environment');
     self._env.save(callback);
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var Environment = require('./env');
 var EventEmitter = require('events').EventEmitter;
 var ServiceManager = require('./service-manager');
@@ -381,23 +382,22 @@ Server.prototype.env = function(baseEnv) {
   return this._env.merged(baseEnv || {});
 };
 
-Server.prototype.updateEnv = function(env) {
+Server.prototype.updateEnv = function(env, callback) {
   debug('Updating environment with: %j', env);
-  for (var k in env) {
-    debug('Setting env: [%j, %j]', k, env[k]);
-    if (env[k] == null) {
-      this._env.unset(k);
-    } else {
-      this._env.set(k, env[k]);
-    }
-  }
+  this._env.apply(env);
   var self = this;
   this._env.save(function(err) {
-    assert.ifError(err);
     debug('Saved environment: ', arguments);
-    assert.ifError(err);
+    if (err) {
+      if (callback) {
+        return callback(err);
+      } else {
+        throw err;
+      }
+    }
     var current = runner.current();
     if (current) {
+      // make copy of current app but with an updated environment
       var commit = cicadaCommit(runner.current().commit);
       commit.config = configForCommit(commit);
       commit.env = self.env();
@@ -406,6 +406,7 @@ Server.prototype.updateEnv = function(env) {
     } else {
       debug('No current app to restart');
     }
+    callback && callback();
   });
 };
 

--- a/lib/service-manager.js
+++ b/lib/service-manager.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var MeshServiceManager = require('strong-mesh-models').ServiceManager;
 var configDefaults = require('./config').configDefaults;
 var debug = require('debug')('strong-pm:service-manager');
@@ -28,6 +29,19 @@ ServiceManager.prototype.onInstanceUpdate =
       [util.format('sl-run --cluster=%s', instance.cpus)];
     debug('  start now: %j', configDefaults.start);
     setImmediate(callback);
+  };
+
+ServiceManager.prototype.onServiceUpdate =
+  function onServiceUpdate(instance, callback) {
+    var localEnv = this.server.env();
+    if (!_.isEqual(instance.env, localEnv)) {
+      // updateEnv uses nulls to indicate unsetting of existing variables
+      var mask = _.mapValues(localEnv, _.constant(null));
+      var update = _.defaults(instance.env, mask);
+      this.server.updateEnv(update, callback);
+    } else {
+      setImmediate(callback);
+    }
   };
 
 module.exports = ServiceManager;

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,8 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-VAGRANTFILE_API_VERSION = "2"
-
 $pkg_name = ENV['PKG_NAME'] || Dir["../strong-pm-*.tgz"].last
 $node_version = ENV['NODE_VER'] || "0.10.33"
 $NODE_URL = "http://nodejs.org/dist/v#{$node_version}/node-v#{$node_version}-linux-x64.tar.gz"
@@ -43,7 +41,7 @@ $test = <<SCRIPT
   sudo tail -20 /var/log/upstart/strong-pm.log
 SCRIPT
 
-Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+Vagrant.configure("2") do |config|
 
   # Ubuntu 12.04 is a reasonable starting point
   config.vm.box = "ubuntu/precise64"

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -37,7 +37,7 @@ $test = <<SCRIPT
   report test -f /etc/init/strong-pm.conf
   report sudo start strong-pm
   report sudo status strong-pm
-  sleep 1
+  sleep 5
   sudo tail -20 /var/log/upstart/strong-pm.log
 SCRIPT
 

--- a/test/helper-async.js
+++ b/test/helper-async.js
@@ -146,6 +146,7 @@ function queued(t) {
   var newT = {
     queue: queue,
     waiton: partial(addStep, queue, waiton, t),
+    wait: partial(addStep, queue, wait, t),
     expect: partial(addStep, queue, expect, t),
     failon: partial(addStep, queue, failon, t),
     shutdown: partial(runTests, queue, t),
@@ -233,6 +234,11 @@ function waiton(t, extra, cmd, pattern, next) {
       setTimeout(check, 1000);
     });
   }
+}
+
+function wait(t, extra, time, reason, next) {
+  t.ok(true, fmt('%dms pause: %', time, reason));
+  setTimeout(next, time);
 }
 
 function failon(t, extra, cmd, pattern, next) {

--- a/test/test-e2e-docker.sh
+++ b/test/test-e2e-docker.sh
@@ -63,7 +63,9 @@ make npm_config_registry=${npm_config_registry:-$(npm config get registry)} cont
 docker build -t strong-pm:test container
 docker_run strong-pm:test
 
-cd app
+# If this fails, bail out, otherwise we could do irreparable damage to the
+# parent strong-pm repo if run from the wrong directory
+cd app || exit 1
 rm -rf .git .strong-pm
 git clean -f -x -d .
 git init .

--- a/test/test-e2e-docker.sh
+++ b/test/test-e2e-docker.sh
@@ -151,6 +151,6 @@ done
 
 ../../bin/sl-pmctl.js -C $STRONGLOOP_PM_NOAUTH status \
   && echo 'not ok # pmctl status should fail without auth' \
-  || echo 'not # pmctl failed to run status without auth'
+  || echo 'ok # pmctl failed to run status without auth'
 
 docker stop $SL_PM

--- a/test/test-e2e-vagrant.sh
+++ b/test/test-e2e-vagrant.sh
@@ -19,7 +19,9 @@ PKG_NAME=$PKG NODE_VER=0.10.33 vagrant up --provision
 
 echo '# strong-pm running in VM'
 
-cd app
+# If this fails, bail out, otherwise we could do irreparable damage to the
+# parent strong-pm repo if run from the wrong directory
+cd app || exit 1
 rm -rf .git .strong-pm
 git clean -f -x -d .
 git init .

--- a/test/test-env.js
+++ b/test/test-env.js
@@ -8,6 +8,20 @@ test('Environment constructor works without a file', function(t) {
   t.end();
 });
 
+test('Basic API sanity', function(t) {
+  var env = new Environment();
+  var merged = env.merged(process.env);
+  t.equivalent(merged, process.env, 'empty merged with env == env');
+  t.isNot(merged, process.env, 'merged is a new object');
+  env.set('FOO', 'bar');
+  t.equivalent(env.merged({}), {FOO: 'bar'}, 'sets a variable');
+  env.apply({FOO: null, BAZ: 'baz'});
+  t.equivalent(env.merged({}), {BAZ: 'baz'}, 'sets and unsets variables');
+  env.unset('BAZ');
+  t.equivalent(env.merged({}), {}, 'unsets a variable');
+  t.end();
+});
+
 test('Environment constructor with file', function(t) {
   sandbox(function(SANDBOX) {
     var env = new Environment(SANDBOX.empty);

--- a/test/test-pmctl-env.js
+++ b/test/test-pmctl-env.js
@@ -5,7 +5,7 @@ helper.test('pmctl', function(t, pm) {
 
   t.waiton(pmctl('status'), /current:$/m);
 
-  t.test('env get/set/unset', function(t) {
+  t.test('env get/set/unset', function testEnv(t) {
     t.expect(pmctl('set-size', '1'));
     t.waiton(pmctl('status'), /worker count: *1/);
 

--- a/test/test-pmctl-log.js
+++ b/test/test-pmctl-log.js
@@ -10,9 +10,7 @@ tap.test('pmctl log', function(t) {
       t = helper.queued(t);
       t.waiton(pmctl('status'), /worker count: *1/);
       t.expect(pmctl('log-dump'), /.+ worker:1 pid \d+ listening on \d+/);
-      t.expect(pmctl('log-dump'), /.*/); // clear any output
-      t.expect(pmctl('log-dump'), /.*/); // once more, reduce timing noise
-      t.expect(pmctl('log-dump'), /^\n$/); // no output
+      t.expect(pmctl('log-dump'), /.*/); // repeated calls are successful
       t.shutdown(pm);
     });
   });
@@ -23,9 +21,7 @@ tap.test('pmctl log', function(t) {
       t = helper.queued(t);
       t.waiton(pmctl('status'), /worker count: *1/);
       t.expect(pmctl('log-dump'), /.+ worker:1 pid \d+ listening on \d+/);
-      t.expect(pmctl('log-dump'), /.*/); // clear any output
-      t.expect(pmctl('log-dump'), /.*/); // once more, reduce timing noise
-      t.expect(pmctl('log-dump'), /^\n$/); // no output
+      t.expect(pmctl('log-dump'), /.*/); // repeated calls are successful
       t.shutdown(pm);
     });
   });

--- a/test/test-server-env.js
+++ b/test/test-server-env.js
@@ -1,0 +1,54 @@
+var Server = require('../lib/server');
+var mktmpdir = require('mktmpdir');
+var test = require('tap').test;
+
+test('new server', function(t) {
+  mktmpdir(function(err, tmpdir, cleanup) {
+    t.on('end', cleanup);
+
+    var s = new Server('pm', tmpdir, 0, null);
+    var Service = s._app.models.ServerService;
+    var svc = null;
+
+    var emptyEnv = {};
+    var fullEnv = {FOO: 'foo', BAR: 'bar'};
+
+    t.test('start server', function(tt) {
+      s.start(function(err) {
+        tt.ifError(err);
+        tt.end();
+      });
+    });
+
+    t.test('initial environment', function(tt) {
+      Service.findById(1, function(err, _svc) {
+        tt.ifError(err, 'finds Service instance');
+        svc = _svc;
+        tt.equivalent(svc.env, emptyEnv, 'model env is empty');
+        tt.equivalent(s.env({}), emptyEnv, 'local env is empty');
+        tt.end();
+      });
+    });
+
+    t.test('update env on model', function(tt) {
+      svc.env = fullEnv;
+      svc.save(function(err, res) {
+        tt.ifError(err, 'saves without error');
+        tt.equivalent(res.env, fullEnv, 'saved env on model');
+        tt.end();
+      });
+    });
+
+    t.test('update reflected locally', function(tt) {
+      tt.equivalent(s.env({}), fullEnv, 'local env was updated');
+      tt.end();
+    });
+
+    t.test('shutdown server', function(tt) {
+      s.stop(function(err) {
+        tt.ifError(err, 'server shutdown without error');
+        tt.end();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Replaces `env-set` and `env-unset` with Service model methods provided by strongloop/strong-mesh-models#21 and replaces `env-get` with model instance access.

Based on #134 
Connected to #48 