### PR TITLE
local-deploy: use concat-stream, and adjust debug

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
         "no-bitwise": 0,
         "no-caller": 2,
         "no-catch-shadow": 0,
-        "no-comma-dangle": 0,
+        "comma-dangle": 0,
         "no-cond-assign": 2,
         "no-console": 0,
         "no-constant-condition": 2,

--- a/lib/local-deploy.js
+++ b/lib/local-deploy.js
@@ -1,17 +1,19 @@
+var concat = require('concat-stream');
 var configForCommit = require('./config').configForCommit;
 var crypto = require('crypto');
 var fs = require('fs');
 var serverCommit = require('strong-fork-cicada/lib/commit');
 var url = require('url');
-var debug = require('debug')('LocalDeploy');
+var debug = require('debug')('strong-pm:local-deploy');
 
 function LocalDeployer(_server) {
   this.server = _server;
 }
 
 LocalDeployer.prototype.sendError = function(res, err) {
+  debug('error 400: %s', err);
   res.writeHead(400);
-  res.end('An error occurred while processing the local deployment: ' + err);
+  res.end('Local deploy failed: ' + err);
 };
 
 LocalDeployer.prototype.processLocalDir = function(req, res, dirPath, hash) {
@@ -22,6 +24,9 @@ LocalDeployer.prototype.processLocalDir = function(req, res, dirPath, hash) {
   if (parsedUrl.pathname && parsedUrl.pathname !== '') {
     repo = parsedUrl.pathname.slice(1) || 'default';
   }
+
+  debug('processLocalDir: id=%s dir=%s repo=%s branch=%s',
+        id, dirPath, repo, branch);
 
   var branch = 'local-directory';
   var commit = serverCommit({
@@ -45,10 +50,10 @@ LocalDeployer.prototype.computeHash = function(req, res, dirPath) {
   shasum.update(dirPath);
   fs.stat(dirPath, function(err, stats) {
     if (err) {
-      return self.sendError(res, 'Directory `' + dirPath + '` does not exist');
+      return self.sendError(res, '`' + dirPath + '` does not exist');
     }
     if (!stats.isDirectory()) {
-      return self.sendError(res, 'Path `' + dirPath + '` is not a directory');
+      return self.sendError(res, '`' + dirPath + '` is not a directory');
     }
 
     var hash = shasum.digest('hex');
@@ -59,23 +64,19 @@ LocalDeployer.prototype.computeHash = function(req, res, dirPath) {
 LocalDeployer.prototype.handle = function(req, res) {
   var self = this;
 
-  var postData = '';
-  req.on('data', function(buf) {
-    postData += buf;
-  });
-
-  req.on('end', function() {
+  req.pipe(concat(function(postData) {
+    debug('%s', postData);
     try {
       var postObj = JSON.parse(postData);
       if (!postObj.hasOwnProperty('local-directory')) {
-        return self.sendError(res, 'Local directory not specified');
+        return self.sendError(res, 'local directory not specified');
       }
 
       self.computeHash(req, res, postObj['local-directory']);
     } catch (err) {
-      return self.sendError(res, 'Error parsing request: ' + err.message);
+      return self.sendError(res, 'error parsing request: ' + err.message);
     }
-  });
+  }));
 
   req.on('error', function(err) {
     self.sendError(req, res, err);

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "bl": "^0.9.4",
     "chownr": "0.0.1",
     "compression": "^1.1.0",
-    "concat-stream": "^1.4.6",
+    "concat-stream": "^1.4.7",
     "debug": "^2.0.0",
     "errorhandler": "^1.2.0",
     "express": "^4.12.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "sl-pm-install": "./bin/sl-pm-install.js"
   },
   "devDependencies": {
-    "eslint": "git://github.com/eslint/eslint",
+    "eslint": "0.15.0",
     "jscs": "^1.11.3",
     "loopback-sdk-angular": "1.3.3",
     "mktmpdir": "^0.1.1",


### PR DESCRIPTION
- Shorten the error messages, they were too verbose, wrapping over
  several lines.
- Use concat-stream to concatenate a request stream.
- Add debug messages so local-deploy DEBUG output isn't silent on
  failure.