### PR TITLE
Pass description option when installing service.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -265,6 +265,7 @@ function resolveIds(options, callback) {
 
 function setCommand(options, callback) {
   options.name = 'strong-pm';
+  options.description = 'StrongLoop Process Manager';
   options.pmBaseDir = path.resolve(options.cwd, options.pmBaseDir);
   options.command = [
     process.execPath,

--- a/test/test-install-systemd.sh
+++ b/test/test-install-systemd.sh
@@ -18,6 +18,7 @@ assert_exit 0 $CMD --port 7777 \
 # Simple lines that should be in the service file for this config
 assert_file $TMP/systemd.service "ExecStart=$(node -p process.execPath)"
 assert_file $TMP/systemd.service "WorkingDirectory=$HOME"
+assert_file $TMP/systemd.service "Description=StrongLoop Process Manager"
 
 unset SL_PM_INSTALL_IGNORE_PLATFORM
 assert_report


### PR DESCRIPTION
When listing services, for example with `systemctl` - the default pre-set description "a node app" was not very descriptive. We should set the description to something more representing.

The following change will for example result in systemd output looking like this:

```shell
systemctl | grep strong
strong-pm.service     loaded active running   StrongLoop Process Manager
```
```shell
systemctl status | grep strong
strong-pm.service - StrongLoop Process Manager
   Loaded: loaded (/etc/systemd/system/strong-pm.service; enabled)
   CGroup: name=systemd:/system/strong-pm.service
```