### PR TITLE
pm-install: preserve basedir during upgrade

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -244,7 +244,13 @@ function fillInHome(options, callback) {
       options.env = options.env || {};
       options.env.HOME = user.homedir;
       options.cwd = user.homedir;
-      options.pmBaseDir = options.pmBaseDir || options.cwd;
+      var defaultBaseDir = options.cwd;
+      var oldDefaultBaseDir = path.resolve(options.cwd, '.strong-pm');
+      // honour old .strong-pm default for existing installs that used it
+      if (fs.existsSync(oldDefaultBaseDir)) {
+        defaultBaseDir = oldDefaultBaseDir;
+      }
+      options.pmBaseDir = options.pmBaseDir || defaultBaseDir;
     }
     callback(err);
   });

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 $pkg_name = ENV['PKG_NAME'] || Dir["../strong-pm-*.tgz"].last
-$node_version = ENV['NODE_VER'] || "0.10.33"
+$node_version = ENV['NODE_VER'] || "0.10.36"
 $NODE_URL = "http://nodejs.org/dist/v#{$node_version}/node-v#{$node_version}-linux-x64.tar.gz"
 npm_config_registry = ENV['npm_config_registry'] ||
                       `npm config get registry`.strip ||
@@ -64,8 +64,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: $test, privileged: false
 
   # expose manager's port
-  config.vm.network "forwarded_port", guest: 7777, host: 7777
+  config.vm.network "forwarded_port", guest: 7777, host: 8702
   # expose sample app's port
-  config.vm.network "forwarded_port", guest: 8888, host: 8888
+  config.vm.network "forwarded_port", guest: 8888, host: 8889
 
 end

--- a/test/test-e2e-vagrant.sh
+++ b/test/test-e2e-vagrant.sh
@@ -15,8 +15,10 @@ fi
 PKG=$(npm pack ..)
 
 PKG_NAME=$PKG vagrant destroy --force
-PKG_NAME=$PKG NODE_VER=0.10.33 vagrant up --provision
+PKG_NAME=$PKG NODE_VER=0.10.36 vagrant up --provision
 
+PM_URL=http://127.0.0.1:8702
+APP_URL=http://127.0.0.1:8889
 echo '# strong-pm running in VM'
 
 # If this fails, bail out, otherwise we could do irreparable damage to the
@@ -29,46 +31,46 @@ echo "PORT=8888" > .env
 git add .
 git commit --author="sl-pm-test <nobody@strongloop.com>" -m "initial"
 sl-build --install --commit
-git push --quiet http://localhost:7777/repo HEAD
+git push --quiet $PM_URL/repo HEAD
 
 echo "# waiting for manager to deploy our app..."
 sleep 5
 echo "# polling...."
-while ! curl -sI http://localhost:8888/this/is/a/test; do
+while ! curl -sI $APP_URL/this/is/a/test; do
   echo "# nothing yet, sleeping for 5s..."
   sleep 5
 done
 
-curl -s http://localhost:8888/env \
+curl -s $APP_URL/env \
   | grep -F -e '"SL_PM_VAGRANT": "42"' \
   && echo 'ok # seed environment includes SL_PM_VAGRANT=42 via pm-install' \
   || echo 'not ok # failed to set SL_PM_VAGRANT=42 via pm-install'
 
-curl -s http://localhost:8888/this/is/a/test \
+curl -s $APP_URL/this/is/a/test \
   | grep -F -e '/this/is/a/test' \
   && echo 'ok # echo server responded' \
   || echo 'not ok # echo server failed to respond'
 
-../../bin/sl-pmctl.js -C http://localhost:7777/ env-set foo=success bar=foo \
+../../bin/sl-pmctl.js -C $PM_URL env-set foo=success bar=foo \
   | grep -F -e 'Environment updated' \
   && echo 'ok # pmctl env-set command ran without error' \
   || echo 'not ok # failed to run env-set foo=success'
 
 sleep 5 # Long enough for app to restart
 
-curl -s http://localhost:8888/env \
+curl -s $APP_URL/env \
   | grep -F -e '"foo": "success"' \
   && echo 'ok # set foo=success via pmctl' \
   || echo 'not ok # failed to set foo=success via pmctl'
 
-../../bin/sl-pmctl.js -C http://localhost:7777/ env-unset foo \
+../../bin/sl-pmctl.js -C $PM_URL env-unset foo \
   | grep -F -e 'Environment updated' \
   && echo 'ok # pmctl env-set command ran without error' \
   || echo 'not ok # failed to run env-set foo=success'
 
 sleep 5 # Long enough for app to restart
 
-curl -s http://localhost:8888/env \
+curl -s $APP_URL/env \
   | grep -F -e '"foo": "success"' \
   && echo 'not ok # failed to unset foo via pmctl' \
   || echo 'ok # unset foo via pmctl'

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -86,9 +86,14 @@ assert_exit 0 $CMD --port 7777 \
                    --job-file $TMP/upstart-with-basedir.conf \
                    --user `id -un`
 
-# Should not be a subdir of $HOME, should be exactly $HOME
-assert_not_file $TMP/upstart-with-basedir.conf "--base $HOME/"
-assert_file $TMP/upstart-with-basedir.conf "--base $HOME"
+# TODO: find another way to test his without depending on the real $HOME
+if [ -d $HOME/.strong-pm ]; then
+  assert_file $TMP/upstart-with-basedir.conf "--base $HOME/.strong-pm"
+else
+  # Should not be a subdir of $HOME, should be exactly $HOME
+  assert_not_file $TMP/upstart-with-basedir.conf "--base $HOME/"
+  assert_file $TMP/upstart-with-basedir.conf "--base $HOME"
+fi
 
 unset SL_PM_INSTALL_IGNORE_PLATFORM
 assert_report

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -51,7 +51,7 @@ assert_file $TMP/upstart.conf "$(node -p process.execPath) $(which sl-pm.js)"
 assert_not_file $TMP/upstart.conf "--config"
 
 # Should NOT add unwanted auth to config
-assert_not_file $TMP/upstart.conf "STRONG_PM_HTTP_AUTH"
+assert_not_file $TMP/upstart.conf "STRONGLOOP_PM_HTTP_AUTH"
 
 # Should create base for us
 assert_exit 0 test -d $TMP/deeply/nested/sl-pm


### PR DESCRIPTION
Old installations will have used a .strong-pm basedir, but that is no
longer the default. If an existing .strong-pm is found, assume it is
from an old install and use it instead of the new default.