### PR TITLE
docker: use official node image as base

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,8 @@
-FROM nodesource/node
+FROM node:0.10
 
-# Ensure git is installed (used by strong-pm)
-# Create "strong-pm" user
-RUN npm install --unsafe-perm --global strongloop/strong-pm#production \
-    && npm cache clean \
-    && useradd -ms /bin/bash strong-pm
+RUN useradd -ms /bin/bash strong-pm \
+    && chown -R strong-pm:strong-pm /usr/local \
+    && su strong-pm -c "npm install -g strong-pm && npm cache clear"
 
 # Set up some semblance of an environment
 WORKDIR /home/strong-pm
@@ -13,11 +11,7 @@ ENV HOME=/home/strong-pm PORT=3000
 # Run as non-privileged user inside container
 USER strong-pm
 
-# pre-load node-gyp to speed up build time of apps pushed to strong-pm
-# and remove need to download node source in production
-RUN node-gyp install 2> /dev/null && npm cache clear
-
 # Expose strong-pm port
 EXPOSE 8701 3000
 
-ENTRYPOINT ["/usr/bin/sl-pm", "--base", ".", "--listen", "8701"]
+ENTRYPOINT ["/usr/local/bin/sl-pm", "--base", ".", "--listen", "8701"]

--- a/test/Dockerfile.in
+++ b/test/Dockerfile.in
@@ -1,22 +1,16 @@
-FROM nodesource/node:trusty
-
-RUN apt-get install -yq git && apt-get clean
-# RUN node-gyp install
+FROM node:0.10
 
 # Create "strongloop" user
-RUN useradd -ms /bin/bash strongloop
-# && chown -R strongloop /usr/local
-# Let everyone run sudo without a password (dangerous!)
-RUN echo "ALL	ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN useradd -ms /bin/bash strongloop \
+    && chown -R strongloop /usr/local
 
 # Set up some semblance of an environment
 WORKDIR /home/strongloop
 ENV HOME /home/strongloop
 USER strongloop
-RUN node-gyp install && npm cache clear
 
 # actual work..
 COPY strong-pm.tgz /home/strongloop/
-RUN sudo npm install --registry NPM_CONFIG_REGISTRY --global strong-pm.tgz
+RUN npm install --registry NPM_CONFIG_REGISTRY --global strong-pm.tgz
 
-ENTRYPOINT ["/usr/bin/sl-pm"]
+ENTRYPOINT ["/usr/local/bin/sl-pm"]


### PR DESCRIPTION
nodesource/node has been deprecated and the replacement doesn't get
updated as quickly as the official image.

Also change the Dockerfile to pull strong-pm from npm instead of the
production branch of the strongloop/strong-pm repo.