### PR TITLE
package: bump to 4.x for multi-app support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strong-pm",
   "description": "StrongLoop Process Manager",
-  "version": "3.1.9",
+  "version": "4.0.0",
   "keywords": [
     "StrongLoop",
     "agent",


### PR DESCRIPTION
Multi-app has API v6, up from v5, and has an incompatible CLI.