### PR TITLE
update ctl handler to use instance env

### DIFF
--- a/lib/ctl.js
+++ b/lib/ctl.js
@@ -7,7 +7,7 @@ module.exports = onCtlRequest;
 function onCtlRequest(options, req, callback) {
   debug('request %j', req);
 
-  var instanceId = req.serviceId;
+  var instanceId = req.serviceId || '1';
   var server = options.server;
   var cmd = req.cmd;
   var rsp = {}; // Clear this response if the handler will callback itself.
@@ -44,7 +44,7 @@ function onCtlRequest(options, req, callback) {
     case 'env-get':
       // configured only, not actual environment
       // XXX(sam) supervisor now supports getting the actual env
-      rsp.env = server.env(instanceId);
+      rsp = getEnv(server, instanceId, rsp, callback);
       break;
 
     case 'log-dump':
@@ -119,6 +119,17 @@ function setEnv(server, env, instanceId, rsp, callback) {
   server.setInstanceEnv(instanceId, env, function(err) {
     if (err) {
       rsp.error = err.message;
+    }
+    return callback(rsp);
+  });
+}
+
+function getEnv(server, instanceId, rsp, callback) {
+  server.getInstanceEnv(instanceId, function(err, env) {
+    if (err) {
+      rsp.error = err.message;
+    } else {
+      rsp.env = env;
     }
     return callback(rsp);
   });


### PR DESCRIPTION
Fixes compatibility with 3.x clients, like Arc 1.x

Connect to strongloop-internal/scrum-nodeops#512