### PR TITLE
server: support old-style deploy to /

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -91,6 +91,7 @@ function Server(options) {
   this._meshApp = MeshServer(this._serviceManager, meshOptions);
   this._baseApp.use(auth(process.env.STRONGLOOP_PM_HTTP_AUTH));
   this._baseApp.use(this._meshApp);
+  this._baseApp.use(this._serviceManager.handle);
   this._isStarted = false;
 
   // Pass properties to avoid dependencies on private properties.

--- a/lib/service-manager.js
+++ b/lib/service-manager.js
@@ -15,11 +15,49 @@ module.exports = ServiceManager;
 function ServiceManager(server) {
   this._server = server;
   this._meshApp = null;
+
+  // Bind handle to this for use as middleware.
+  this.handle = this.handle.bind(this);
 }
 
 util.inherits(ServiceManager, MeshServiceManager);
 
 var prototype = ServiceManager.prototype;
+
+// Support pm v3.x/mesh v5.x deployments, by directing all these requests to
+// service 'default' as deploy requests. Default will be created if it doen't
+// exist.
+prototype.handle = function(req, res, next) {
+  var url = req.url;
+
+  if (!/\/default$/.test(url) && !/\/default\/.*/.test(url))
+    return next();
+
+  debug('handle old-style deploy to: %s', req.url);
+
+  var Service = this._meshApp.models.ServerService;
+  var name = 'default';
+  var filter = {
+    order: ['id ASC'],
+    where: {
+      or: [
+        {name: name},
+        {id: 1},
+      ]
+    },
+  };
+  var service = {name: name, _groups: [{id: 1, name: 'default', scale: 1}]};
+
+  Service.findOrCreate(filter, service, function(err, service) {
+    if (err) {
+      console.error('service-manager: handle.findOrCreate: %s', err);
+      return next(err);
+    }
+    debug('old-style deploy to svc %j name %j', service.id, service.name);
+
+    service.deploy(req, res, next);
+  });
+};
 
 // On first run of pm, the default models will be created in the DB (a single
 // executor, etc.). On next run, any existing processes will be marked as

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -41,6 +41,7 @@ tap.test('server test', function(t) {
     var serviceManager;
     function MockServiceManager(o) {
       this.options = o;
+      this.handle = function(req,res,next) {};
       serviceManager = this;
     }
 
@@ -125,6 +126,7 @@ tap.test('server test', function(t) {
     var serviceManager;
     function MockServiceManager(o) {
       this.options = o;
+      this.handle = function(req,res,next) {};
       serviceManager = this;
     }
 

--- a/test/test-service-manager.js
+++ b/test/test-service-manager.js
@@ -4,6 +4,92 @@ var ServiceManager = require('../lib/service-manager');
 var meshServer = require('strong-mesh-models').meshServer;
 var tap = require('tap');
 
+tap.test('old-style git deploy', function(t) {
+  var req = {
+    url: '/default/a-bunch?of-git-stuff',
+  };
+  var res = {
+    setHeaders: function(status, values) {
+      console.error('setHeaders: %j %j', status, values);
+    },
+    end: function(body) {
+      t.assert(false, body);
+      t.end();
+    },
+  };
+  var next = function() {};
+  var server = {
+    getDefaultEnv: function() { return {}; },
+    updateInstanceEnv: function(_, __, callback) { callback();  },
+    deployInstance: deployInstance,
+  };
+  var sm = new ServiceManager(server);
+  var meshApp = meshServer(sm);
+
+  sm.initOrUpdateDb(meshApp, function(err) {
+    t.ifError(err, 'load failed');
+
+    sm.handle(req, res, next);
+  });
+
+  function deployInstance(_, _req, _res) {
+    t.equal(_req, req);
+    t.equal(_res, res);
+    t.end();
+  }
+});
+
+tap.test('old-style local or pack deploy', function(t) {
+  var req = {
+    url: '/default',
+  };
+  var res = {};
+  var next = function() {};
+  var server = {
+    getDefaultEnv: function() { return {}; },
+    updateInstanceEnv: function(_, __, callback) { callback();  },
+    deployInstance: deployInstance,
+  };
+  var sm = new ServiceManager(server);
+  var meshApp = meshServer(sm);
+
+  sm.initOrUpdateDb(meshApp, function(err) {
+    t.ifError(err, 'load failed');
+
+    sm.handle(req, res, next);
+  });
+
+  function deployInstance(_, _req, _res) {
+    t.equal(_req, req);
+    t.equal(_res, res);
+    t.end();
+  }
+});
+
+tap.test('old-style leaves non-deploy routes alone', function(t) {
+  var req = {
+    url: '/api',
+  };
+  var res = {};
+  var next = function() {
+    t.assert(true, 'passes through');
+    t.end();
+  };
+  var server = {
+    getDefaultEnv: function() { return {}; },
+    updateInstanceEnv: function(_, __, callback) { callback();  },
+  };
+  var sm = new ServiceManager(server);
+  var meshApp = meshServer(sm);
+
+  sm.initOrUpdateDb(meshApp, function(err) {
+    t.ifError(err, 'load failed');
+
+    sm.handle(req, res, next);
+  });
+});
+
+
 tap.test('construction', function(t) {
   var server = {};
   var sm = new ServiceManager(server);


### PR DESCRIPTION
Current pm uses deploy to /api/Service/<svc-id>/deploy, but old-style
deploys to /, and arc needs to work with both old (pre-multiapp) and new
process managers.

connected to strongloop-internal/scrum-nodeops#511
