### PR TITLE
log when an app/service starts listening on a port

### DIFF
--- a/lib/drivers/direct/container.js
+++ b/lib/drivers/direct/container.js
@@ -63,6 +63,8 @@ function Container(options) {
     trace: false,
   });
 
+  this.ports = [];
+
   // XXX(sam) might be able to use a single cicada, made in the driver, and
   // using the repo set to the svcId, but this works fine.
   this._svcDir = path.resolve(this.baseDir, 'svc', String(this.instanceId));
@@ -237,6 +239,8 @@ Container.prototype._onPrepared = function(commit) {
   }
 
   function run() {
+    // reset listening ports
+    self.ports = [];
     self.run(commit);
   }
 };

--- a/lib/drivers/direct/direct-driver.js
+++ b/lib/drivers/direct/direct-driver.js
@@ -25,6 +25,7 @@ function Driver(options) {
   this._server = mandatory(options.server);
 
   this._containers = Object.create(null);
+  this.on('request', this._onRequest.bind(this));
 }
 
 util.inherits(Driver, EventEmitter);
@@ -154,6 +155,18 @@ Driver.prototype._containerById = function(instanceId) {
   }
 
   return container;
+};
+
+Driver.prototype._onRequest = function(instanceId, req) {
+  var instance = this._containerById(instanceId);
+  switch(req.cmd) {
+    case 'listening':
+      // emit a listening event each time a new port is listened on
+      if (instance.ports.indexOf(req.address.port) < 0) {
+        instance.ports.push(req.address.port);
+        this.emit('listening', instanceId, req.address);
+      }
+  }
 };
 
 Driver.prototype.getName = function() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -106,6 +106,7 @@ function Server(options) {
   this.onCtlRequest = onCtlRequest.bind(null, ctlOptions);
 
   this._driver.on('request', this._onInstanceRequest.bind(this));
+  this._driver.on('listening', this._onInstanceListening.bind(this));
 }
 
 util.inherits(Server, EventEmitter);
@@ -315,6 +316,14 @@ Server.prototype._onInstanceRequest = function(instanceId, req, callback) {
       if (callback) return callback();
     }
   );
+};
+
+Server.prototype._onInstanceListening = function(instanceId, address) {
+  this._serviceManager.getInstanceMetas(function(err, instanceMetas) {
+    if (err) return;
+    console.log('Service "%s" listening on %s:%d',
+                instanceId, address.address, address.port);
+  });
 };
 
 Server.prototype.start = function start(cb) {


### PR DESCRIPTION
Driver API contract gains the requirement to emit a 'listening' event
whenever an instance starts listening on a new address/port. How this
is tracked is up to the driver, but the event should emit the
instanceId and an object containing address and port fields.

Connect to strongloop-internal/scrum-nodeops#507