### PR TITLE
prepare: redirect stderr to stdout

### DIFF
--- a/lib/drivers/common/prepare.js
+++ b/lib/drivers/common/prepare.js
@@ -47,13 +47,16 @@ function spawn(dir, env, cmd, callback) {
   var options = {
     cwd: dir,
     env: _.extend({}, process.env, env),
-    stdio: 'inherit',
+    stdio: ['ignore', debug.enabled ? 'inherit' : 'ignore', 'pipe'],
   };
   args.shift(); // Discard the leading 'npm'.
-  return npm(args, options).on('exit', function(code, signal) {
+  var child = npm(args, options).on('exit', function(code, signal) {
     if (code === 0) return callback();
     var err = Error(signal || code);
     err.command = cmd;
     return err;
   });
+  // redirect stderr to stdout to better consolidate npm output in PM logs
+  child.stderr.pipe(process.stdout, {end: false});
+  return child;
 }


### PR DESCRIPTION
Better for consolidating npm output in PM logs.

@sam-github did we want to still do the debug based filtering idea you came up with? Or just the stderr redirecting? This version does both.