### PR TITLE
Dynamic set size

### DIFF
--- a/lib/drivers/direct/container.js
+++ b/lib/drivers/direct/container.js
@@ -88,10 +88,23 @@ function Container(options) {
 util.inherits(Container, App);
 
 Container.prototype.setStartOptions = function(options) {
+  var self = this;
+  var original = util._extend({}, this._startOptions);
   util._extend(this._startOptions, options);
 
   this.options.start = this.getStartCommand();
   this.debug('setStartOptions: %j, cmd %s', options, this.options.start);
+
+  if (options.size != null && options.size !== original.size) {
+    self.debug('set-size: %j', options.size);
+    this.request({cmd: 'set-size', size: options.size}, function(rsp) {
+      self.debug('set-size %j: rsp %j', options.size, rsp);
+    });
+  }
+
+  // if (options.trace != null) {
+  //   XXX(sam) need to restart the worker so tracing can be enabled/disabled
+  //}
 };
 
 Container.prototype.getStartCommand = function() {

--- a/lib/drivers/direct/index.js
+++ b/lib/drivers/direct/index.js
@@ -58,7 +58,9 @@ Driver.prototype.start = function(instanceMetas, callback) {
   });
 
   function run(instanceId, callback) {
-    debug('start current for instance %j', instanceId);
+    var size = instanceMetas[instanceId].size;
+    debug('start at size %j for instance %j', size, instanceId);
+    self._containerById(instanceId).setStartOptions({size: size});
     self._containerById(instanceId).runCurrent(callback);
   }
 

--- a/lib/service-manager.js
+++ b/lib/service-manager.js
@@ -198,9 +198,7 @@ prototype.onApiRequest = function(req, callback) {
   });
 };
 
-// Called 'before save' of ServiceInstance.
-// XXX(sam) this includes updates made from PM, so setStartOptions() may
-// need to filter out calls if there is no change.
+// Called 'after save' of ServiceInstance.
 prototype.onInstanceUpdate = function(instance, callback) {
   debug('onInstanceUpdate: iid %j cpus %j', instance.id, instance.cpus);
 
@@ -337,6 +335,9 @@ prototype.getInstanceMetas = function(callback) {
       var instance = instances[i];
       debug('%s: %j', iid(instance), instance.containerVersionInfo);
       metas[instance.id] = instance.containerVersionInfo;
+
+      debug('%s: size %j', iid(instance), instance.cpus);
+      metas[instance.id].size = instance.cpus;
     }
     callback(null, metas);
   });

--- a/test/test-direct-driver.js
+++ b/test/test-direct-driver.js
@@ -43,10 +43,13 @@ tap.test('start runs last services', function(t) {
         _.pull(instanceIds, options.instanceId);
         return callback();
       },
+      setStartOptions: function(options) {
+        t.assert('size' in options);
+      },
     }
   }
 
-  t.plan(5);
+  t.plan(8);
 
   d.start(instanceMetas, function(er) {
     t.ifError(er);


### PR DESCRIPTION
Previously, a change in the instance.cpus value caused the start command
to be updated, but this didn't take effect under most scenarios.

On initial start of an instance from the saved meta, the supervisor was
being started with the default value for size, not the instance.cpus.

When a supervisor was already running, only the start command was
changing, but that has no effect on a supervisor that is already
started.

With this change, the expected size is included in the instance meta, so
effects the initial start of the supervisor. Also, when the size
changes, a set-size request is sent to the currently running supervisor,
if any, so that it can change its size dynamically.

connected to strongloop-internal/scrum-nodeops#537