### PR TITLE
service-manager: robust to missing json

### DIFF
--- a/lib/service-manager.js
+++ b/lib/service-manager.js
@@ -334,11 +334,15 @@ prototype.getInstanceMetas = function(callback) {
     for (var i in instances) {
       if (!instances.hasOwnProperty(i)) continue;
       var instance = instances[i];
-      debug('%s: %j', iid(instance), instance.containerVersionInfo);
-      metas[instance.id] = instance.containerVersionInfo;
+      var meta = instance.containerVersionInfo;
+      debug('%s: meta %j', iid(instance), meta);
 
-      debug('%s: size %j', iid(instance), instance.cpus);
-      metas[instance.id].size = instance.cpus;
+      if (meta) {
+        metas[instance.id] = meta;
+
+        debug('%s: size %j', iid(instance), instance.cpus);
+        metas[instance.id].size = instance.cpus;
+      }
     }
     callback(null, metas);
   });


### PR DESCRIPTION
containerVersionInfo isn't necessarily present.