### PR TITLE
Mark processes dead more robustly on startup

### DIFF
--- a/lib/service-manager.js
+++ b/lib/service-manager.js
@@ -61,7 +61,7 @@ prototype.handle = function(req, res, next) {
 
 // On first run of pm, the default models will be created in the DB (a single
 // executor, etc.). On next run, any existing processes will be marked as
-// stopped (since on statup PM has no children).
+// stopped (since on startup PM has no children).
 // XXX(sam) Its not true that there are no children in the Docker case... the
 // docker driver will have to report status on any live children it finds,
 // and the processes will become alive again.
@@ -92,14 +92,20 @@ prototype.initOrUpdateDb = function(meshApp, callback) {
 
   function stopStaleProcesses(err) {
     if (err) return callback(err);
-    Process.find({where: {stopReason: ''}}, function(err, procs) {
+    Process.find(function(err, procs) {
       if (err) return callback(err);
       async.each(procs, stopProcess, callback);
     });
   }
 
   function stopProcess(proc, callback) {
-    debug('mark stopped: pid %s wid %d', proc.pid, proc.workerId);
+    // Anything other than null, undefined, or '' is a reason.
+    if (proc.stopReason == null || proc.stopReason === '') {
+      console.log('NOT mark stopped: pid %j wid %j reason %j',
+            proc.pid, proc.workerId, proc.stopReason);
+      return callback();
+    }
+    debug('mark stopped: pid %j wid %j', proc.pid, proc.workerId);
     proc.stopReason = 'StrongLoop Process Manager was stopped';
     proc.stopTime = new Date();
     proc.save(callback);


### PR DESCRIPTION
connected to strongloop-internal/scrum-nodeops#571