### PR TITLE
WIP: Driver refactor

### DIFF
--- a/lib/drivers/common/log-buffer.js
+++ b/lib/drivers/common/log-buffer.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var bl = require('bl');
+
+module.exports = exports = makeLogBuffer;
+
+// This is a soft limit that is only checked/enforced once per LOG_GC interval.
+exports.MAX_LOG_RETENTION_BYTES = 1 * 1024 * 1024;
+exports.LOG_GC_INTERVAL_MS = 30 * 1000;
+
+function makeLogBuffer() {
+  var logger = bl();
+
+  logger.enableGC = function() {
+    logger._logGcTimer = logger._logGcTimer || makeGcTimer();
+  };
+
+  logger.dump = function() {
+    var logDump = logger.duplicate().toString();
+    logger.consume(logDump.length);
+    return logDump;
+  };
+
+  logger.on('end', function() {
+    if (logger._logGcTimer) {
+      clearInterval(logger.logGcTimer);
+      logger._logGcTimer = null;
+    }
+  });
+
+  return logger;
+
+  function gcLogger() {
+    var overflow = logger.length - exports.MAX_LOG_RETENTION_BYTES;
+    if (overflow > 0) {
+      logger.consume(overflow);
+    }
+  }
+
+  function makeGcTimer() {
+    var timer = setInterval(gcLogger, exports.LOG_GC_INTERVAL_MS);
+    timer.unref();
+    return timer;
+  }
+}

--- a/lib/drivers/direct/container.js
+++ b/lib/drivers/direct/container.js
@@ -4,12 +4,12 @@ var App = require('strong-runner').App;
 var Debug = require('debug');
 var _ = require('lodash');
 var assert = require('assert');
-var bl = require('bl');
 var c2s = require('strong-runner').Runnable.toString;
 var cicada = require('strong-fork-cicada');
 var cicadaCommit = require('strong-fork-cicada/lib/commit');
 var fs = require('fs');
 var localDeploy = require('../common/local-deploy');
+var logBuffer = require('../common/log-buffer');
 var mandatory = require('./../../util').mandatory;
 var packReceiver = require('../common/pack-receiver');
 var path = require('path');
@@ -42,12 +42,8 @@ function Container(options) {
   this.debug = Debug('strong-pm:container:' + this.instanceId);
 
   //this.restartCount = 0; // XXX(sam) move here from strong-runner.App?
-  this._appLog = bl();
-  this._logGcTimer = setInterval(
-    this._gcLogs.bind(this),
-    exports.LOG_GC_INTERVAL_MS
-  );
-  this._logGcTimer.unref();
+  this._appLog = logBuffer();
+  this._appLog.enableGC();
 
   this.stdout.pipe(this._appLog, {end: false});
   this.stderr.pipe(this._appLog, {end: false});
@@ -304,21 +300,11 @@ Container.prototype.updateInstanceEnv = function(env, callback) {
   self.emit('prepared', commit);
 };
 
-// This is a soft limit that is only checked/enforced once per LOG_GC interval.
-exports.MAX_LOG_RETENTION_BYTES = 1 * 1024 * 1024;
-exports.LOG_GC_INTERVAL_MS = 30 * 1000;
-
-Container.prototype._gcLogs = function() {
-  var overflow = this._appLog.length - exports.MAX_LOG_RETENTION_BYTES;
-  if (overflow > 0) {
-    this._appLog.consume(overflow);
+Container.prototype.dumpLogs = function() {
+  if (this.current) {
+    return this._appLog.dump();
+  } else {
+    return null;
   }
-};
 
-Container.prototype.readableLogSnapshot = function() {
-  return this._appLog.duplicate();
-};
-
-Container.prototype.flushLogs = function() {
-  this._appLog.consume(this._appLog.length);
 };

--- a/lib/drivers/direct/container.js
+++ b/lib/drivers/direct/container.js
@@ -83,6 +83,22 @@ function Container(options) {
   // Happens after a new-deploy is prepared, and also when a previously prepared
   // service is found at startup.
   this.on('prepared', this._onPrepared);
+
+  var self = this;
+  this.on('request', function(req) {
+    var supervisorPid;
+    if (req.cmd === 'started') {
+      supervisorPid = req.pid;
+      self.current.once('exit', function(status) {
+        self.emit('request', {
+          cmd: 'exit',
+          id: 0,
+          pid: supervisorPid,
+          reason: status,
+        });
+      });
+    }
+  });
 }
 
 util.inherits(Container, App);

--- a/lib/drivers/direct/index.js
+++ b/lib/drivers/direct/index.js
@@ -110,28 +110,11 @@ Driver.prototype.removeInstance = function(instanceId, callback) {
 
 Driver.prototype.dumpInstanceLog = function(instanceId) {
   var container = this._containerById(instanceId);
-  var log = container.readableLogSnapshot().toString();
-  var logLength = log === null ? undefined : log.length;
+  debug('dumpInstanceLog(%j) size: %j current? %j child? %j',
+        instanceId, current, child);
   var current = !!container.current;
   var child = current ? !!container.current.child : undefined;
-
-  container.flushLogs();
-
-  debug('dumpInstanceLog(%j) size: %j current? %j child? %j',
-        instanceId, logLength, current, child);
-
-  // Distinguish between no log data because there is no data, and no log
-  // data because there is no running child by setting log data to empty
-  // string.
-  /* eslint eqeqeq:0 */
-  if (log == '' && !child) {
-    log = null;
-  }
-  if (log == null && child) {
-    log = '';
-  }
-
-  return log;
+  return container.dumpLogs();
 };
 
 Driver.prototype.updateInstanceEnv = function(instanceId, env, callback) {

--- a/lib/drivers/direct/index.js
+++ b/lib/drivers/direct/index.js
@@ -125,6 +125,16 @@ Driver.prototype.requestOfInstance = function(instanceId, req, callback) {
   this._containerById(instanceId).request(req, callback);
 };
 
+Driver.prototype.instanceById = function(id) {
+  var container = this._containerById(id);
+  var current = container.current;
+  var instance = container.instance;
+  instance.pid = current && current.child && current.child.pid;
+  instance.commit = current.commit;
+  instance.restartCount = current.restartCount;
+  return instance;
+};
+
 Driver.prototype._containerById = function(instanceId) {
   var container = this._containers[instanceId];
 
@@ -136,6 +146,7 @@ Driver.prototype._containerById = function(instanceId) {
       server: this._server,
       instanceId: instanceId,
     });
+    container.instance = {};
     container.on('request', this.emit.bind(this, 'request', instanceId));
   }
 

--- a/lib/drivers/docker/container.js
+++ b/lib/drivers/docker/container.js
@@ -17,12 +17,10 @@ function Container(image, instanceId, logger, startOpts) {
   this.docker = image.docker;
   this.instanceId = instanceId;
   this.shouldRestart = true;
-  this.pid = process.pid;
   this.connected = false;
   this.image = image;
   this.commit = image.commit;
   this.restartCount = 0;
-  this.child = {pid: 1};
   this.logger = logger;
   this.startOpts = startOpts;
   this.env = startOpts.env;

--- a/lib/drivers/docker/container.js
+++ b/lib/drivers/docker/container.js
@@ -5,6 +5,7 @@ var debug = require('debug');
 var EventEmitter = require('events').EventEmitter;
 var fmt = require('util').format;
 var inherits = require('util').inherits;
+var isError = require('util').isError;
 var sCtl = require('strong-control-channel/client');
 
 module.exports = exports = Container;
@@ -45,6 +46,16 @@ function Container(image, instanceId, logger, startOpts) {
   this.on('connected', function() {
     setImmediate(function() {
       self._onConnected();
+    });
+  });
+  this.on('exit', function(status) {
+    setImmediate(function() {
+      self.emit('request', {
+        cmd: 'exit',
+        pid: 1,
+        id: 0,
+        reason: isError(status) ? 1 : status,
+      });
     });
   });
   this._connectAttempts = 0;

--- a/lib/drivers/docker/index.js
+++ b/lib/drivers/docker/index.js
@@ -126,6 +126,7 @@ DockerDriver.prototype.startInstance = function(id, cb) {
     instance.currentImage = imgToLaunch;
     delete instance.nextImage;
     instance.current = imgToLaunch.start(id, instance.log, opts);
+    instance.commit = imgToLaunch.commit;
     instance.current.on('request', function(req) {
       debug('bubbling up request from instance %j:', id,
             _.pick(req, ['pid', 'wid', 'pst', 'cmd']));
@@ -304,6 +305,7 @@ DockerDriver.prototype._resume = function(id, meta) {
   var instance = this._instance(id);
   var Image = this.Image;
   var image = instance.nextImage = new Image(this, id, this.baseDir);
+  instance.commit = meta.commit;
   image.commit = meta.commit;
   image.emit('commit', meta.commit);
   image.on('error', function(err) {
@@ -332,11 +334,14 @@ DockerDriver.prototype.stop = function(cb) {
   }
 };
 
-DockerDriver.prototype._instance =
-DockerDriver.prototype._containerById = function(id) {
+DockerDriver.prototype.instanceById =
+DockerDriver.prototype._instance = function(id) {
   this._instances[id] = this._instances[id] || {
     startOpts: _.clone(this.defaultStartOptions),
     log: logBuffer(),
+    pid: 1,
+    commit: {},
+    restartCount: 0,
   };
   return this._instances[id];
 };

--- a/lib/drivers/docker/index.js
+++ b/lib/drivers/docker/index.js
@@ -2,7 +2,6 @@
 
 var _ = require('lodash');
 var async = require('async');
-var bl = require('bl');
 var debug = require('debug')('strong-pm:docker:driver');
 var Docker = require('dockerode');
 var EventEmitter = require('events').EventEmitter;
@@ -10,6 +9,7 @@ var fmt = require('util').format;
 var Image = require('./image');
 var inherits = require('util').inherits;
 var isError = require('util').isError;
+var logBuffer = require('../common/log-buffer');
 var mandatory = require('./../../util').mandatory;
 
 module.exports = exports = DockerDriver;
@@ -195,13 +195,12 @@ DockerDriver.prototype.stopInstance = function(id, style, cb) {
 DockerDriver.prototype.dumpInstanceLog = function(id) {
   debug('DockerDriver.dumpInstanceLog(%j)', id);
   var instance = this._instance(id);
-  if (!instance.current) {
+  if (instance.current) {
+    return instance.log.dump();
+  } else {
     debug('no instance to dump logs for: %j', id);
     return null;
   }
-  var logDump = instance.log.duplicate().toString();
-  instance.log.consume(logDump.length);
-  return logDump;
 };
 
 DockerDriver.prototype.updateInstanceEnv = function(id, env, cb) {
@@ -337,42 +336,10 @@ DockerDriver.prototype._instance =
 DockerDriver.prototype._containerById = function(id) {
   this._instances[id] = this._instances[id] || {
     startOpts: _.clone(this.defaultStartOptions),
-    log: makeLogBuffer(),
+    log: logBuffer(),
   };
   return this._instances[id];
 };
-
-// TODO: extract this log buffer to drivers/common
-// This is a soft limit that is only checked/enforced once per LOG_GC interval.
-exports.MAX_LOG_RETENTION_BYTES = 1 * 1024 * 1024;
-exports.LOG_GC_INTERVAL_MS = 30 * 1000;
-
-function makeLogBuffer() {
-  var logger = bl();
-  logger.enableGC = function() {
-    logger._logGcTimer = logger._logGcTimer || makeGcTimer();
-  };
-  logger.on('end', function() {
-    if (logger._logGcTimer) {
-      clearInterval(logger.logGcTimer);
-      logger._logGcTimer = null;
-    }
-  });
-  return logger;
-
-  function gcLogger() {
-    var overflow = logger.length - exports.MAX_LOG_RETENTION_BYTES;
-    if (overflow > 0) {
-      logger.consume(overflow);
-    }
-  }
-
-  function makeGcTimer() {
-    var timer = setInterval(gcLogger, exports.LOG_GC_INTERVAL_MS);
-    timer.unref();
-    return timer;
-  }
-}
 
 DockerDriver.prototype.getName = function() {
   return 'Docker';

--- a/lib/server.js
+++ b/lib/server.js
@@ -203,8 +203,7 @@ Server.prototype.requestOfInstance = function(instanceId, req, callback) {
 Server.prototype._onInstanceStarted = function(instanceId, startedRequest, cb) {
   var self = this;
 
-  // XXX(KR) remove ref to container
-  // TODO(rmg) what is needed from container is "current", which must have:
+  // TODO(rmg) current must have:
   //   .commit member
   //   .restartCount member
   //   .appName member
@@ -212,8 +211,7 @@ Server.prototype._onInstanceStarted = function(instanceId, startedRequest, cb) {
   //   .child member
   //      .pid sub-member
   //   @rmg but .child should not be relied on, its direct specific
-  var container = this._driver._containerById(instanceId);
-  var current = container.current;
+  var current = this._driver._containerById(instanceId).current;
   var commit = current.commit;
 
   var strongPmInfo = require('../package.json');
@@ -274,15 +272,13 @@ Server.prototype._onInstanceRequest = function(instanceId, req, callback) {
   // XXX(sam) seems like this code should be in either Container, or in
   // strong-supervisor?
 
-  // XXX(KR) remove ref to container
-  var container = this._driver._containerById(instanceId);
-  var current = container.current;
+  var current = this._driver._containerById(instanceId).current;
   if (req.cmd === 'started') {
     current.appName = req.appName;
     current.agentVersion = req.agentVersion;
     req.restartCount = current.restartCount;
   } else if (req.cmd === 'fork') {
-    req.ppid = container.current.child.pid;
+    req.ppid = current.child.pid;
   }
 
   // Relay notifications to parent process if present
@@ -297,26 +293,21 @@ Server.prototype._onInstanceRequest = function(instanceId, req, callback) {
     return self._onInstanceStarted(instanceId, req, function(err) {
       assert.ifError(err);
       // XXX(sam) for test code? used anywhere?
-      self.emit('running', container.current.commit);
+      self.emit('running', current.commit);
       if (callback) return callback();
     });
   }
 
-  return self._meshApp.handleModelUpdate(
-    instanceId,
-    req,
-    function(err) {
-      assert.ifError(err);
-
-      // Emit events for tests
-      // XXX might not be needed after test refactor
-      if (req.cmd === 'fork' || req.cmd === 'exit') {
-        self.emit(req.cmd, req, container);
-      }
-
-      if (callback) return callback();
+  return self._meshApp.handleModelUpdate(instanceId, req, function(err) {
+    assert.ifError(err);
+    // used for test/test-server-metadata.js
+    if (req.cmd === 'exit') {
+      self.emit(req.cmd, req);
     }
-  );
+    if (callback) {
+      return callback();
+    }
+  });
 };
 
 Server.prototype._onInstanceListening = function(instanceId, address) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -211,7 +211,6 @@ Server.prototype._onInstanceStarted = function(instanceId, startedRequest, cb) {
   //   .agentVersion member
   //   .child member
   //      .pid sub-member
-  //   emits 'exit' event with exit code
   //   @rmg but .child should not be relied on, its direct specific
   var container = this._driver._containerById(instanceId);
   var current = container.current;
@@ -223,17 +222,6 @@ Server.prototype._onInstanceStarted = function(instanceId, startedRequest, cb) {
   this._driver.requestOfInstance(instanceId, {cmd: 'status'}, function(status) {
     if (!self._isStarted) return;
     debug('on running: %s', c2s(commit));
-
-    var supervisorPid = startedRequest.pid;
-    // XXX should be in driver, and maybe be a 'stopped' event?
-    current.once('exit', function(status) {
-      // Sometimes the supervisor process may exit without any events, so we
-      // must record its and its childrens death by simulating an exit
-      // request.
-      self._onInstanceRequest(instanceId, {
-        cmd: 'exit', id: 0, pid: supervisorPid, reason: status
-      }, function() {});
-    });
 
     // Process information
     startedRequest.id = 0; // Supervisor is worker id 0

--- a/lib/server.js
+++ b/lib/server.js
@@ -203,15 +203,7 @@ Server.prototype.requestOfInstance = function(instanceId, req, callback) {
 Server.prototype._onInstanceStarted = function(instanceId, startedRequest, cb) {
   var self = this;
 
-  // TODO(rmg) current must have:
-  //   .commit member
-  //   .restartCount member
-  //   .appName member
-  //   .agentVersion member
-  //   .child member
-  //      .pid sub-member
-  //   @rmg but .child should not be relied on, its direct specific
-  var current = this._driver._containerById(instanceId).current;
+  var current = this._driver.instanceById(instanceId);
   var commit = current.commit;
 
   var strongPmInfo = require('../package.json');
@@ -272,13 +264,13 @@ Server.prototype._onInstanceRequest = function(instanceId, req, callback) {
   // XXX(sam) seems like this code should be in either Container, or in
   // strong-supervisor?
 
-  var current = this._driver._containerById(instanceId).current;
+  var current = this._driver.instanceById(instanceId);
   if (req.cmd === 'started') {
     current.appName = req.appName;
     current.agentVersion = req.agentVersion;
     req.restartCount = current.restartCount;
   } else if (req.cmd === 'fork') {
-    req.ppid = current.child.pid;
+    req.ppid = current.pid;
   }
 
   // Relay notifications to parent process if present

--- a/test/driver-helpers.js
+++ b/test/driver-helpers.js
@@ -56,8 +56,7 @@ function testDriverInstance(tap, i) {
     method(t, i, 'stop', ['cb']);
     method(t, i, 'getName', []);
     method(t, i, 'getStatus', []);
-    // XXX(rmg): to be removed
-    method(t, i, '_containerById', ['id']);
+    method(t, i, 'instanceById', ['id']);
     t.end();
   });
 }

--- a/test/null-driver.js
+++ b/test/null-driver.js
@@ -72,9 +72,13 @@ NullDriver.prototype.stop = function(cb) {
   setImmediate(cb);
 };
 
-NullDriver.prototype._containerById = function(id) {
+NullDriver.prototype.instanceById = function(id) {
   assert(id, 'id is provided');
-  return new EventEmitter();
+  return {
+    commit: {},
+    restartCount: 0,
+    pid: process.pid,
+  };
 };
 
 NullDriver.prototype.getName = function() {

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -175,10 +175,9 @@ tap.test('server test', function(t) {
     var commit = {hash: '123', dir: '/some/dir'};
 
     function MockContainer() {
-      this.current = new events.EventEmitter();
+      this.current = {};
       this.current.commit = commit;
     }
-    util.inherits(MockContainer, events.EventEmitter);
     MockContainer.prototype.request = function request(req, cb) {
       if (req.cmd === 'status') {
         cb({ master: { setSize: 1 } });
@@ -204,6 +203,9 @@ tap.test('server test', function(t) {
         pst: Date.now(),
       });
       callback();
+    };
+    MockDriver.prototype.instanceById = function(instanceId) {
+      return this._containerById(instId).current;
     };
     MockDriver.prototype._containerById = function(instanceId) {
       var container = this._containers[instanceId];


### PR DESCRIPTION
- [x] move instance exit handling out of server (removed event emitter requirement from "container")
- [x] remove `container` from server
- [x] extract common log buffer functionality
- [x] simplify contract between server and service instances returned by driver
- [ ] extract common deployment handler
- [ ] extract common git receiver