### PR TITLE
Improve service installation support for docker driver

### DIFF
--- a/lib/drivers/docker/index.js
+++ b/lib/drivers/docker/index.js
@@ -217,7 +217,6 @@ DockerDriver.prototype.dumpInstanceLog = function(id) {
 
 DockerDriver.prototype.updateInstanceEnv = function(id, env, cb) {
   debug('DockerDriver.updateInstanceEnv(%j)', id);
-  var self = this;
   var current = this._instance(id).current;
   if (!current) {
     debug('no instance to update env of: %j', id);
@@ -229,12 +228,25 @@ DockerDriver.prototype.updateInstanceEnv = function(id, env, cb) {
     return cb && setImmediate(cb);
   } else {
     debug('env changed, restarting %j: %j => %j', id, current.env, env);
-    // env is alredy a copy
+    var unset = _.difference(_.keys(current.env), _.keys(env));
+    // env is already a copy
     current.env = env;
-    return self.requestOfInstance(id, {cmd: 'env-set', env: env}, function() {
-      self.requestOfInstance(id, {cmd: 'restart'}, function(rsp) {
-        cb(rsp && rsp.error, rsp);
-      });
+    async.series([
+      this._ctlCmd(id, {cmd: 'env-unset', env: unset}),
+      this._ctlCmd(id, {cmd: 'env-set', env: env}),
+      this._ctlCmd(id, {cmd: 'restart'}),
+    ], cb);
+  }
+};
+
+DockerDriver.prototype._ctlCmd = function(id, cmd) {
+  var self = this;
+
+  return wrappedCtl;
+
+  function wrappedCtl(next) {
+    self.requestOfInstance(id, cmd, function(rsp) {
+      next(rsp && rsp.error, rsp);
     });
   }
 };

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var async = require('async');
 var child_process = require('child_process');
 var chownr = require('chownr');
@@ -164,6 +165,7 @@ function install(argv, callback) {
 
   var steps = [
     ensureUser, fillInGroup, fillInHome,
+    ensureGroup,
     resolveIds,
     setCommand, ensureBaseDir,
     prepareSeedEnvironment,
@@ -258,6 +260,54 @@ function fillInGroup(options, callback) {
       } else {
         options.group = options.userGroup;
       }
+    }
+    callback(err);
+  });
+}
+
+function ensureGroup(options, callback) {
+  userInRequiredGroup(options.user, options.group, function(err, present) {
+    if (err || present) {
+      return callback(err);
+    }
+    if (options.dryRun) {
+      console.log('skipping user modification in dry-run');
+      return callback();
+    }
+    if (process.platform !== 'linux') {
+      console.log('skipping user modification on non-Linux platform');
+      return callback();
+    }
+    addUserToGroup(options.user, options.group, callback);
+  });
+}
+
+function userInRequiredGroup(user, group, callback) {
+  var cmd = '/usr/bin/id';
+  var args = ['-Gn', user];
+  child_process.execFile(cmd, args, function(err, stdout) {
+    var groups = [];
+    if (err) {
+      console.error('Could not determine groups for service user \'%s\': %s',
+                    user, err.message);
+    } else {
+      groups = stdout.trim().split(/\s+/);
+    }
+    callback(err, _.includes(groups, group));
+  });
+}
+
+function addUserToGroup(user, group, callback) {
+  var cmd = '/usr/sbin/usermod';
+  var args = [
+    '--append',
+    '--groups', group,
+    user,
+  ];
+  child_process.execFile(cmd, args, function(err, stdout, stderr) {
+    if (err) {
+      console.error('Error adding user %s to group %s:\n%s\n%s',
+                    user, group, stdout, stderr);
     }
     callback(err);
   });

--- a/lib/install.js
+++ b/lib/install.js
@@ -167,6 +167,7 @@ function install(argv, callback) {
     ensureUser, fillInGroup, fillInHome,
     ensureGroup,
     resolveIds,
+    ensureDocker,
     setCommand, ensureBaseDir,
     prepareSeedEnvironment,
     writeSeedEnvironment,
@@ -311,6 +312,21 @@ function addUserToGroup(user, group, callback) {
     }
     callback(err);
   });
+}
+
+function ensureDocker(options, callback) {
+  var cmd = 'docker info';
+  var execOpts = {uid: options._userId};
+  if (options.driver === 'docker') {
+    child_process.exec(cmd, execOpts, function(err, stdout, stderr) {
+      if (err) {
+        console.error('Docker not usable by %s:', options.user, stderr);
+      }
+      callback(err);
+    });
+  } else {
+    setImmediate(callback);
+  }
 }
 
 function fillInHome(options, callback) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -193,6 +193,10 @@ function install(argv, callback) {
 }
 
 function ensureUser(options, callback) {
+  var groups = [];
+  if (options.driver === 'docker') {
+    groups.push('docker');
+  }
   userExists(options.user, function(err, exists) {
     if (err || exists)
       return callback(err);
@@ -205,19 +209,23 @@ function ensureUser(options, callback) {
       return callback();
     }
     options.home = '/var/lib/' + options.user;
-    useradd(options.user, options.home, callback);
+    useradd(options.user, options.home, groups, callback);
   });
 }
 
-function useradd(name, home, callback) {
+function useradd(name, home, groups, callback) {
   var cmd = '/usr/sbin/useradd';
   var args = [
     '--home', home,
     '--shell', '/bin/false',
     '--skel', '/dev/null',
     '--create-home', '--user-group', '--system',
-    name
   ];
+  if (groups.length > 0) {
+    args.push('-G');
+    args.push(groups.join(','));
+  }
+  args.push(name);
   child_process.execFile(cmd, args, function(err, stdout, stderr) {
     if (err) {
       console.error('Error adding user %s:\n%s\n%s',

--- a/lib/install.js
+++ b/lib/install.js
@@ -157,6 +157,11 @@ function install(argv, callback) {
     return callback(Error('usage'));
   }
 
+  if (jobConfig.upstart === '0.6' && jobConfig.driver === 'docker') {
+    console.error('Upstart 0.6 does not support setgid. Please run:\n' +
+                  '   "sudo usermod -aG docker %s".', jobConfig.user);
+  }
+
   var steps = [
     ensureUser, fillInGroup, fillInHome,
     resolveIds,
@@ -238,7 +243,13 @@ function fillInGroup(options, callback) {
       console.error('Could not determine group for service user \'%s\': %s',
                     options.user, err.message);
     } else {
-      options.group = stdout.trim();
+      options.userGroup = stdout.trim();
+      if (options.driver === 'docker') {
+        // allows strong-pm to talk to the docker daemon
+        options.group = 'docker';
+      } else {
+        options.group = options.userGroup;
+      }
     }
     callback(err);
   });
@@ -266,10 +277,10 @@ function fillInHome(options, callback) {
 }
 
 function resolveIds(options, callback) {
-  uidNumber(options.user, options.group, function(err, uid, gid) {
+  uidNumber(options.user, options.userGroup, function(err, uid, gid) {
     if (err) {
       console.error('Error getting numeric uid/gid of %s/%s: %s',
-                    options.user, options.group, err.message);
+                    options.user, options.userGroup, err.message);
       return callback(err);
     }
     options._userId = uid;

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "express": "^4.12.0",
     "extsprintf": "^1.2.0",
     "http-auth": "^2.2.5",
-    "lodash": "^2.4.1",
+    "lodash": "^3.9.3",
     "minkelite": "^1.0.0",
     "mkdirp": "^0.5.0",
     "osenv": "^0.1.0",

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,7 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$pkg_name = ENV['PKG_NAME'] || Dir["../strong-pm-*.tgz"].last
+$pkg_name = ENV['PKG_NAME'] ||
+            Dir["strong-pm.tgz", "strong-pm-*.tgz", "../strong-pm-*.tgz"].last
 $node_version = ENV['NODE_VER'] || "v0.10.38"
 $node_name = ENV['NODE_NAME'] || "node"
 $NODEJS_URL = "https://nodejs.org/dist/#{$node_version}/node-#{$node_version}-linux-x64.tar.gz"
@@ -15,8 +16,10 @@ $NPM_REGISTRY = "--registry #{npm_config_registry}"
 $bootstrap = <<SCRIPT
   test -f bootstrapped.txt && exit
   # apt-get update -y -qq
+  wget -qO- https://get.docker.com/ | sh
   apt-get install -y -qq build-essential git curl vim
   mkdir -p ~/.ssh; ssh-keyscan github.com >> ~/.ssh/known_hosts
+  docker pull node:0.10
   touch bootstrapped.txt
 SCRIPT
 
@@ -35,8 +38,8 @@ $test = <<SCRIPT
     ($* && echo "ok # $*") || (echo "not ok # $*" >&2)
     ## ($* > /dev/null && echo "ok # $*") || (echo "not ok # $*" >&2)
   }
-  report npm install #{$NPM_REGISTRY} -g strong-pm.tgz
-  report sudo sl-pm-install --port 8701 --set-env SL_PM_VAGRANT=42
+  report npm install #{$NPM_REGISTRY} -g ./strong-pm.tgz
+  report sudo sl-pm-install --set-env SL_PM_VAGRANT=42 --driver=docker
   report test -f /etc/init/strong-pm.conf
   report sudo start strong-pm
   report sudo status strong-pm

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -9,8 +9,11 @@ console.log('ENV.supervisor_profile:', env.supervisor_profile);
 console.log('ENV.PATH:', env.PATH);
 console.log('ENV.PWD:', env.PWD);
 
-// Check PWD is a symlink to our current working directory.
-assert.notEqual(env.PWD, process.cwd(), 'PWD should not be cwd()');
+// vagrant e2e tests run deployed apps in docker containers, skip symlink check
+if (!env.SL_PM_VAGRANT) {
+  // Check PWD is a symlink to our current working directory.
+  assert.notEqual(env.PWD, process.cwd(), 'PWD should not be cwd()');
+}
 assert.equal(fs.realpathSync(env.PWD), process.cwd());
 
 http.createServer(onRequest)

--- a/test/common.sh
+++ b/test/common.sh
@@ -5,6 +5,20 @@ skips=0
 
 trap assert_report EXIT
 
+function wait_until_available() {
+  local url=$1
+  comment "polling...."
+  polls=0
+  while ! curl -sI $url; do
+    polls=$((polls+1))
+    if test $polls -gt 10; then
+      return 1
+    fi
+    comment "nothing yet, sleeping for 5s..."
+    sleep 5
+  done
+}
+
 function fail() {
   local report=$1
   local output=$2

--- a/test/test-e2e-docker.sh
+++ b/test/test-e2e-docker.sh
@@ -72,20 +72,6 @@ function docker_run() {
   comment "app2 URL: $APP2"
 }
 
-function wait_until_available() {
-  local url=$1
-  comment "polling...."
-  polls=0
-  while ! curl -sI $url; do
-    polls=$((polls+1))
-    if test $polls -gt 10; then
-      return 1
-    fi
-    comment "nothing yet, sleeping for 5s..."
-    sleep 5
-  done
-}
-
 make npm_config_registry=${npm_config_registry:-$(npm config get registry)} container/strong-pm.tgz container/Dockerfile
 ok "prepared Dockerfile for building test image"
 

--- a/test/test-e2e-vagrant.sh
+++ b/test/test-e2e-vagrant.sh
@@ -26,6 +26,10 @@ PKG_NAME=$PKG NODE_NAME=$NODE_NAME NODE_VER=$NODE_VER vagrant up --provision \
   && ok "vagrant VM provisioned" \
   || fail "vagrant VM not provisioned"
 
+vagrant ssh -- id strong-pm | grep docker \
+  && ok 'strong-pm user added to docker group' \
+  || fail 'strong-pm user not added to docker group'
+
 PM_URL=http://127.0.0.1:8702
 APP_URL=http://127.0.0.1:8889
 comment 'strong-pm running in VM'

--- a/test/test-install-systemd.sh
+++ b/test/test-install-systemd.sh
@@ -5,6 +5,8 @@ source common.sh
 # Setup
 CMD="node ../bin/sl-pm-install.js"
 TMP=`mktemp -d -t sl-svc-installXXXXXX`
+CURRENT_USER=`id -un`
+CURRENT_GROUP=`id -gn`
 comment "using tmpdir: $TMP"
 
 export SL_PM_INSTALL_IGNORE_PLATFORM=true
@@ -12,7 +14,7 @@ export SL_PM_INSTALL_IGNORE_PLATFORM=true
 # Should create a systemd service at the specified path
 assert_exit 0 $CMD --port 7777 \
               --job-file $TMP/systemd.service \
-              --user `id -un` \
+              --user $CURRENT_USER \
               --base $TMP/deeply/nested/sl-pm \
               --systemd
 
@@ -21,5 +23,23 @@ assert_file $TMP/systemd.service "ExecStart=$(node -p process.execPath)"
 assert_file $TMP/systemd.service "WorkingDirectory=$HOME"
 assert_file $TMP/systemd.service "Description=StrongLoop Process Manager"
 assert_file $TMP/systemd.service "--driver direct"
+assert_file $TMP/systemd.service "User=$CURRENT_USER"
+assert_file $TMP/systemd.service "Group=$CURRENT_GROUP"
+
+# Should create a systemd service at the specified path
+assert_exit 0 $CMD --port 7777 \
+              --job-file $TMP/systemd-with-docker.service \
+              --user $CURRENT_USER \
+              --base $TMP/deeply/nested/sl-pm \
+              --driver docker \
+              --systemd
+
+# Simple lines that should be in the service file for this config
+assert_file $TMP/systemd-with-docker.service "ExecStart=$(node -p process.execPath)"
+assert_file $TMP/systemd-with-docker.service "WorkingDirectory=$HOME"
+assert_file $TMP/systemd-with-docker.service "Description=StrongLoop Process Manager"
+assert_file $TMP/systemd-with-docker.service "--driver docker"
+assert_file $TMP/systemd-with-docker.service "User=$CURRENT_USER"
+assert_file $TMP/systemd-with-docker.service "Group=docker"
 
 unset SL_PM_INSTALL_IGNORE_PLATFORM

--- a/test/test-install-upstart-0.6.sh
+++ b/test/test-install-upstart-0.6.sh
@@ -5,6 +5,7 @@ source common.sh
 # Setup
 CMD="node ../bin/sl-pm-install.js"
 TMP=`mktemp -d -t sl-svc-installXXXXXX`
+CURRENT_USER=`id -un`
 comment "using tmpdir: $TMP"
 
 export SL_PM_INSTALL_IGNORE_PLATFORM=true
@@ -12,7 +13,7 @@ export SL_PM_INSTALL_IGNORE_PLATFORM=true
 # Should create an upstart job at the specified path
 assert_exit 0 $CMD --port 7777 \
               --job-file $TMP/upstart.conf \
-              --user `id -un` \
+              --user $CURRENT_USER \
               --base $TMP/deeply/nested/sl-pm \
               --upstart 0.6
 
@@ -20,5 +21,6 @@ assert_exit 0 $CMD --port 7777 \
 assert_file $TMP/upstart.conf "mkfifo /tmp/strong-pm"
 assert_file $TMP/upstart.conf "logger -t strong-pm"
 assert_file $TMP/upstart.conf "--driver direct"
+assert_file $TMP/upstart.conf "$CURRENT_USER --"
 
 unset SL_PM_INSTALL_IGNORE_PLATFORM


### PR DESCRIPTION
* [x] run strong-pm as `docker` group
  * minimal change, covers Upstart 1.4 and systemd
* [x] add strong-pm user to `docker` group
  * required to support Upstart 0.6 environments
* [x] detect docker and fail if not found

connect to strongloop-internal/scrum-nodeops#615
connect to strongloop-internal/scrum-nodeops#618