### PR TITLE
Allow app base port to other than 3000

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,0 @@
-node_modules
-test/.vagrant/
-test/SANDBOX*
-test/app-prepare/node_modules
-test/container
-test/receive-base

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,5 @@
 {
-  "excludeFiles": ["node_modules/**", "test/**", ".strong-pm"],
+  "excludeFiles": ["node_modules/**", "test/**", ".strong*"],
   "disallowMixedSpacesAndTabs": true,
   "disallowKeywordsOnNewLine": [],
   "requireCurlyBraces": [

--- a/bin/sl-pm-install.txt
+++ b/bin/sl-pm-install.txt
@@ -9,13 +9,14 @@ Options:
                       applications.
   -b,--base BASE      Base directory to work in (default is $HOME of the user
                       that manager is run as, see --user).
+  -P,--base-port PORT Applications will run at PORT + service ID (default 3000).
   -d,--driver DRIVER  Specify application execution driver. May be  direct or
                       docker (default is direct).
   -e,--set-env K=V... Initial application environment variables. If setting
                       multiple variables they must be quoted into a single
                       argument: "K1=V1 K2=V2 K3=V3".
   -u,--user USER      User to run manager as (default is strong-pm).
-  -p,--port PORT      Listen on PORT for application deployment (default 8701).
+  -p,--port PORT      Listen on PORT for control (default 8701).
   -n,--dry-run        Don't write any files.
   -j,--job-file FILE  Path of Upstart job to create (default is
                       `/etc/init/strong-pm.conf`).

--- a/bin/sl-pm.txt
+++ b/bin/sl-pm.txt
@@ -3,12 +3,13 @@ usage: %MAIN% [options]
 The Strongloop process manager.
 
 Options:
-  -h,--help         Print this message and exit.
-  -v,--version      Print version and exit.
-  -b,--base BASE    Base directory to work in (default `~/.strong-pm`).
-  -l,--listen PORT  Listen on PORT for control (default 8701).
-  --driver DRIVER   Execution backend to use for running apps. Current supported
-                    drivers are 'direct' and 'docker' (default `direct`).
+  -h,--help           Print this message and exit.
+  -v,--version        Print version and exit.
+  -b,--base BASE      Base directory to work in (default `~/.strong-pm`).
+  -l,--listen PORT    Listen on PORT for control (default 8701).
+  -P,--base-port PORT Applications will run at PORT + service ID (default 3000).
+  --driver DRIVER     Execution backend to use for running apps. Current drivers
+                      are 'direct' and 'docker' (default `direct`).
 
 The base directory is used to save deployed applications, for working
 directories, and for any other files the process manager needs to create.

--- a/lib/install.js
+++ b/lib/install.js
@@ -35,6 +35,7 @@ function install(argv, callback) {
       'm:(metrics)',
       'a:(http-auth)',
       'd:(driver)',
+      'P:(base-port)',
     ].join(''),
     argv);
 
@@ -42,6 +43,7 @@ function install(argv, callback) {
     user: 'strong-pm',
     pmBaseDir: null,
     pmPort: 8701,
+    basePort: 3000,
     driver: 'direct',
     dryRun: false,
     jobFile: null, // strong-service-install provides an init-specific default
@@ -76,6 +78,9 @@ function install(argv, callback) {
         break;
       case 'p':
         jobConfig.pmPort = option.optarg | 0; // cast to an integer
+        break;
+      case 'P':
+        jobConfig.basePort = option.optarg | 0; // cast to an integer
         break;
       case 'u':
         jobConfig.user = option.optarg;
@@ -115,6 +120,11 @@ function install(argv, callback) {
   }
 
   if (jobConfig.pmPort < 1) {
+    console.error('Valid port was not specified, try `%s --help`.', $0);
+    return callback(Error('usage'));
+  }
+
+  if (jobConfig.basePort < 1) {
     console.error('Valid port was not specified, try `%s --help`.', $0);
     return callback(Error('usage'));
   }
@@ -222,6 +232,7 @@ function fixupCommand(options, callback) {
     require.resolve('../bin/sl-pm'),
     '--listen', options.pmPort,
     '--base', options.pmBaseDir,
+    '--base-port', options.basePort,
     '--driver', options.driver,
   ].join(' ');
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -77,10 +77,10 @@ function install(argv, callback) {
         jobConfig.pmEnv = option.optarg;
         break;
       case 'p':
-        jobConfig.pmPort = option.optarg | 0; // cast to an integer
+        jobConfig.pmPort = option.optarg;
         break;
       case 'P':
-        jobConfig.basePort = option.optarg | 0; // cast to an integer
+        jobConfig.basePort = option.optarg;
         break;
       case 'u':
         jobConfig.user = option.optarg;
@@ -119,13 +119,15 @@ function install(argv, callback) {
     return callback(Error('usage'));
   }
 
-  if (jobConfig.pmPort < 1) {
-    console.error('Valid port was not specified, try `%s --help`.', $0);
+  if (!(jobConfig.pmPort > 0)) {
+    console.error('Port %j is not valid, try `%s --help`.',
+                  jobConfig.pmPort, $0);
     return callback(Error('usage'));
   }
 
-  if (jobConfig.basePort < 1) {
-    console.error('Valid port was not specified, try `%s --help`.', $0);
+  if (!(jobConfig.basePort > 0)) {
+    console.error('Base port %j is not valid, try `%s --help`.',
+                  jobConfig.basePort, $0);
     return callback(Error('usage'));
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -21,8 +21,6 @@ var os = require('os');
 var path = require('path');
 var processChannel = require('strong-control-channel/process');
 var util = require('util');
-var versionApi = require('strong-mesh-models/package.json').apiVersion;
-var versionPm = require('../package.json').version;
 
 // Extend base without modifying it.
 function extend(base, extra) {
@@ -101,7 +99,7 @@ function Server(options) {
   this._wsRouter = new WebsocketRouter(this._baseHttpServer,
                                        this._baseApp,
                                        'instance-control');
-  this._serviceManager = new ServiceManager(this);
+  this._serviceManager = new ServiceManager(this, options);
   this._meshApp = MeshServer(
     this._serviceManager, this._minkelite, meshOptions);
   this._baseApp.use(auth(process.env.STRONGLOOP_PM_HTTP_AUTH));
@@ -335,13 +333,6 @@ Server.prototype.start = function start(cb) {
     try {
       self._baseHttpServer.listen(self._listenPort, function(err) {
         if (err) return callback(err);
-
-        var address = this.address();
-        console.log('%s: StrongLoop PM v%s (API v%s) listening on port `%s`',
-          self._cmdName,
-          versionPm,
-          versionApi,
-          address.port);
 
         // The HTTP server. This is used when stopping PM and to get the address
         // that PM is listening on

--- a/lib/service-manager.js
+++ b/lib/service-manager.js
@@ -12,9 +12,12 @@ var _ = require('lodash');
 
 module.exports = ServiceManager;
 
-function ServiceManager(server) {
+function ServiceManager(server, options) {
   this._server = server;
   this._meshApp = null;
+  this._basePort = (options && Number(options.basePort)) || 3000;
+
+  debug('options: %j', options);
 
   // Bind handle to this for use as middleware.
   this.handle = this.handle.bind(this);
@@ -250,7 +253,7 @@ prototype.onServiceUpdate = function(service, callback) {
   }
 
   function updateEnvironment(callback) {
-    var env = getServiceEnv(service);
+    var env = getServiceEnv(service, self._basePort);
 
     service.instances(true, function(err, instances) {
       if (err) return callback(err);
@@ -308,6 +311,7 @@ prototype.onDeployment = function(service, req, res) {
 };
 
 prototype.getInstanceEnv = function(instanceId, callback) {
+  var self = this;
   var models = this._meshApp.models;
   var Instance = models.ServiceInstance;
 
@@ -323,7 +327,7 @@ prototype.getInstanceEnv = function(instanceId, callback) {
           Error('Unable to find service for instance with id ' + instanceId)
         );
 
-      var env = getServiceEnv(service);
+      var env = getServiceEnv(service, self._basePort);
 
       // Override env so strong-trace returns the instanceId as the hostname
       env.STRONGLOOP_TRACES_ID = String(instanceId);
@@ -334,7 +338,6 @@ prototype.getInstanceEnv = function(instanceId, callback) {
   });
 };
 
-// XXX(sam) rename to getContainerVersionInfos()
 prototype.getInstanceMetas = function(callback) {
   var models = this._meshApp.models;
   var Instance = models.ServiceInstance;
@@ -375,9 +378,9 @@ ServiceManager.prototype.getApiVersionInfo = function(callback) {
   }));
 };
 
-function getServiceEnv(service) {
+function getServiceEnv(service, basePort) {
   var hostEnv = _.pick(process.env, 'STRONGLOOP_LICENSE');
-  var servicePortEnv = {PORT: String(3000 + service.id)};
+  var servicePortEnv = {PORT: String(basePort + service.id)};
   return _.merge(hostEnv, servicePortEnv, service.env);
 }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint --ignore-path .gitignore . && jscs .",
-    "test": "tap --bail --timeout=1000 --save=failed.txt ./test/test-*"
+    "test": "tap --bail --timeout=1000 ./test/test-*"
   },
   "bin": {
     "sl-pm": "./bin/sl-pm.js",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
   "license": "Artistic-2.0 OR LicenseRef-LICENSE.md",
   "main": "index.js",
   "scripts": {
-    "pretest": "eslint ./ && jscs ./",
-    "lint": "eslint ./ && jscs ./",
+    "pretest": "eslint --ignore-path .gitignore . && jscs .",
     "test": "tap --bail --timeout=1000 --save=failed.txt ./test/test-*"
   },
   "bin": {
@@ -48,7 +47,7 @@
     "sl-pm-install": "./bin/sl-pm-install.js"
   },
   "devDependencies": {
-    "eslint": "^0.22.1",
+    "eslint": "^0.24.0",
     "jscs": "^1.11.3",
     "mktmpdir": "^0.1.1",
     "request": "^2.45.0",

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -96,7 +96,7 @@ assert_exit 0 $CMD --port 7777 \
                    --user $CURRENT_USER \
                    --driver docker
 
-# TODO: find another way to test his without depending on the real $HOME
+# TODO: find another way to test this without depending on the real $HOME
 if [ -d $HOME/.strong-pm ]; then
   assert_file $TMP/upstart-with-basedir.conf "--base $HOME/.strong-pm"
 else
@@ -107,6 +107,7 @@ fi
 
 # Should create an upstart job at the specified path
 assert_exit 0 $CMD --port 7777 \
+		   --base-port 8888 \
                    --job-file $TMP/upstart-with-docker.conf \
                    --user $CURRENT_USER \
                    --driver docker
@@ -114,5 +115,7 @@ assert_not_file $TMP/upstart-with-docker.conf "--driver direct"
 assert_file $TMP/upstart-with-docker.conf "--driver docker"
 assert_file $TMP/upstart-with-docker.conf "setuid $CURRENT_USER"
 assert_file $TMP/upstart-with-docker.conf "setgid docker"
+assert_file $TMP/upstart-with-docker.conf "--listen 7777"
+assert_file $TMP/upstart-with-docker.conf "--base-port 8888"
 
 unset SL_INSTALL_IGNORE_PLATFORM


### PR DESCRIPTION
It defaults to 3000, but that isn't useful if you have apps running on
your host in the 3000+ range already. Its also unworkable if you have
multiple instances of pm on the same host.

should do for strong-central, as well.

connected to strongloop-internal/scrum-nodeops#623

/cc @seanbrookes @cgole 
