### PR TITLE
Report driver metadata for each instance

### DIFF
--- a/lib/drivers/direct/index.js
+++ b/lib/drivers/direct/index.js
@@ -130,8 +130,9 @@ Driver.prototype.instanceById = function(id) {
   var current = container.current;
   var instance = container.instance;
   instance.pid = current && current.child && current.child.pid;
-  instance.commit = current.commit;
-  instance.restartCount = current.restartCount;
+  instance.commit = current && current.commit || {hash: null, dir: null};
+  instance.restartCount = current && current.restartCount;
+  instance.driverMeta = {};
   return instance;
 };
 
@@ -146,7 +147,9 @@ Driver.prototype._containerById = function(instanceId) {
       server: this._server,
       instanceId: instanceId,
     });
-    container.instance = {};
+    container.instance = {
+      driverMeta: {},
+    };
     container.on('request', this.emit.bind(this, 'request', instanceId));
   }
 

--- a/lib/drivers/docker/index.js
+++ b/lib/drivers/docker/index.js
@@ -137,6 +137,11 @@ DockerDriver.prototype.startInstance = function(id, cb) {
     instance.currentImage = imgToLaunch;
     delete instance.nextImage;
     instance.current = imgToLaunch.start(id, instance.log, opts);
+    instance.current.on('created', function() {
+      instance.driverMeta.user = {
+        container: instance.current.cid,
+      };
+    });
     instance.commit = imgToLaunch.commit;
     instance.current.on('request', function(req) {
       debug('bubbling up request from instance %j:', id,

--- a/lib/drivers/docker/index.js
+++ b/lib/drivers/docker/index.js
@@ -363,8 +363,9 @@ DockerDriver.prototype._instance = function(id) {
     startOpts: _.clone(this.defaultStartOptions),
     log: logBuffer(),
     pid: 1,
-    commit: {},
+    commit: {hash: null, dir: null},
     restartCount: 0,
+    driverMeta: {},
   };
   return this._instances[id];
 };

--- a/lib/install.js
+++ b/lib/install.js
@@ -3,6 +3,7 @@ var async = require('async');
 var child_process = require('child_process');
 var chownr = require('chownr');
 var debug = require('debug')('strong-pm:install');
+var Docker = require('dockerode');
 var Environment = require('./env');
 var fs = require('fs');
 var mkdirp = require('mkdirp');
@@ -315,12 +316,11 @@ function addUserToGroup(user, group, callback) {
 }
 
 function ensureDocker(options, callback) {
-  var cmd = 'docker info';
-  var execOpts = {uid: options._userId};
   if (options.driver === 'docker') {
-    child_process.exec(cmd, execOpts, function(err, stdout, stderr) {
+    var docker = new Docker();
+    docker.info(function(err) {
       if (err) {
-        console.error('Docker not usable by %s:', options.user, stderr);
+        console.error('Docker not usable:', err);
       }
       callback(err);
     });

--- a/lib/server.js
+++ b/lib/server.js
@@ -264,6 +264,7 @@ Server.prototype._onInstanceStarted = function(instanceId, startedRequest, cb) {
         hash: commit.hash,
         dir: commit.dir,
       },
+      driverMeta: current.driverMeta,
     };
     startedRequest.commitHash = commit.hash;
     startedRequest.setSize = startedRequest.setSize || status.master.setSize;

--- a/test/driver-helpers.js
+++ b/test/driver-helpers.js
@@ -59,6 +59,17 @@ function testDriverInstance(tap, i) {
     method(t, i, 'instanceById', ['id']);
     t.end();
   });
+
+  tap.test('driver instance object', function(t) {
+    var svc = i.instanceById(1);
+    t.assert('driverMeta' in svc, 'instances have driverMeta');
+    t.assert('restartCount' in svc, 'instances have restartCount');
+    t.assert('commit' in svc, 'instances have commit');
+    t.assert('hash' in svc.commit, 'commit has hash');
+    t.assert('dir' in svc.commit, 'commit has dir');
+    t.assert('pid' in svc, 'instances have a pid');
+    t.end();
+  });
 }
 
 function method(t, inst, fname, args) {

--- a/test/null-driver.js
+++ b/test/null-driver.js
@@ -75,9 +75,10 @@ NullDriver.prototype.stop = function(cb) {
 NullDriver.prototype.instanceById = function(id) {
   assert(id, 'id is provided');
   return {
-    commit: {},
+    commit: {hash: null, dir: null},
     restartCount: 0,
     pid: process.pid,
+    driverMeta: null,
   };
 };
 


### PR DESCRIPTION
Uses the metadata support from strongloop/strong-mesh-models#69 to expose the docker container id of an instance when using the docker driver.

Connect to strongloop-internal/scrum-nodeops#485

Includes a fixup for #222.