### PR TITLE
log app logs to PM's log

### DIFF
--- a/lib/drivers/direct/container.js
+++ b/lib/drivers/direct/container.js
@@ -46,7 +46,9 @@ function Container(options) {
   this._appLog.enableGC();
 
   this.stdout.pipe(this._appLog, {end: false});
+  this.stdout.pipe(process.stdout, {end: false});
   this.stderr.pipe(this._appLog, {end: false});
+  this.stderr.pipe(process.stderr, {end: false});
 
   this._startOptions = {};
   this.setStartOptions({

--- a/lib/drivers/direct/index.js
+++ b/lib/drivers/direct/index.js
@@ -175,16 +175,16 @@ Driver.prototype._containerById = function(instanceId) {
       container.request = request;
       container.channel = channel;
       container.setStartOptions({control: control});
-
-      function onRequest(req, callback) {
-        container.emit('request', req, callback);
-      }
     }
 
     container.on('request', this.emit.bind(this, 'request', instanceId));
   }
 
   return container;
+
+  function onRequest(req, callback) {
+    container.emit('request', req, callback);
+  }
 };
 
 Driver.prototype._onRequest = function(instanceId, req) {


### PR DESCRIPTION
@sam-github I propose this as an interim fix to restore the previous behaviour that was removed in 0b6ba97f67 (#188) until we can come up with a better solution. Without this, app logs are basically thrown away.

Connect to strongloop-internal/scrum-nodeops#614

/cc @ijroth 