### PR TITLE
docker: remove --driver from CLI usage

### DIFF
--- a/bin/sl-pm-install.txt
+++ b/bin/sl-pm-install.txt
@@ -9,8 +9,6 @@ Options:
                       applications.
   -b,--base BASE      Base directory to work in (default is $HOME of the user
                       that manager is run as, see --user).
-  -d,--driver DRIVER  Specify application execution driver. May be  direct or
-                      docker (default is direct).
   -e,--set-env K=V... Initial application environment variables. If setting
                       multiple variables they must be quoted into a single
                       argument: "K1=V1 K2=V2 K3=V3".

--- a/bin/sl-pm.txt
+++ b/bin/sl-pm.txt
@@ -9,8 +9,6 @@ Options:
   -l,--listen PORT  Listen on PORT for git pushes (default 8701).
   -C,--control CTL  Listen for local control messages on CTL (default `pmctl`).
   --no-control      Do not listen for local control messages.
-  --driver DRIVER   Execution backend to use for running apps. Current supported
-                    drivers are 'direct' and 'docker' (default `direct`).
 
 The base directory is used to save deployed applications, for working
 directories, and for any other files the process manager needs to create.


### PR DESCRIPTION
This hides docker support until its formally published.
