### PR TITLE
Upgrade tap to 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "pretest": "eslint ./ && jscs ./",
     "lint": "eslint ./ && jscs ./",
-    "test": "tap --timeout=1000 ./test/test-*"
+    "test": "tap --bail --timeout=1000 ./test/test-*"
   },
   "bin": {
     "sl-pm": "./bin/sl-pm.js",
@@ -59,7 +59,7 @@
     "shelljs": "^0.3.0",
     "strong-build": "^1.0.0",
     "strong-deploy": "^2.0.0",
-    "tap": "^0.7.0"
+    "tap": "^1.2.0"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/test/test-e2e-docker.sh
+++ b/test/test-e2e-docker.sh
@@ -176,3 +176,5 @@ wait_until_available $APP1/this/is/a/test \
   || ok 'pmctl failed to run status without auth'
 
 docker stop $SL_PM
+
+assert_report


### PR DESCRIPTION
This passes locally, except for the e2e shell script test, which seems to not be outputting a plan. I'm not familiar with tap protocol internals, can you take a look?