### PR TITLE
fix error in error handler

### DIFF
--- a/lib/service-manager.js
+++ b/lib/service-manager.js
@@ -290,13 +290,13 @@ prototype.onDeployment = function(service, req, res) {
   service.instances(function(err, instances) {
     if (err) {
       debug(err);
-      res.setHeaders(500, {});
+      res.status(500).set({});
       res.end('Error while deploying: ' + err.message);
       return;
     }
     if (instances.length <= 0) {
       debug(err);
-      res.setHeaders(500, {});
+      res.status(500).set({});
       res.end('Error while deploying: no instance found');
       return;
     }

--- a/test/test-service-manager.js
+++ b/test/test-service-manager.js
@@ -9,8 +9,13 @@ tap.test('old-style git deploy', function(t) {
     url: '/default/a-bunch?of-git-stuff',
   };
   var res = {
-    setHeaders: function(status, values) {
-      console.error('setHeaders: %j %j', status, values);
+    set: function(k, v) {
+      console.error('set: %j %j', key, value);
+      return this;
+    },
+    status: function(status) {
+      console.error('status: %j', status);
+      return this;
     },
     end: function(body) {
       t.assert(false, body);


### PR DESCRIPTION
Use res.status().set() instead of fictional res.setHeaders().

Connect to strongloop-internal/scrum-nodeops#712

/to @sam-github @kraman whichever of you is available, PTAL.
/cc @cgole 