### PR TITLE
service-manager: allow application port to be set

### DIFF
--- a/lib/service-manager.js
+++ b/lib/service-manager.js
@@ -372,7 +372,7 @@ ServiceManager.prototype.getApiVersionInfo = function(callback) {
 function getServiceEnv(service) {
   var hostEnv = _.pick(process.env, 'STRONGLOOP_LICENSE');
   var servicePortEnv = {PORT: String(3000 + service.id)};
-  return _.merge(hostEnv, service.env, servicePortEnv);
+  return _.merge(hostEnv, servicePortEnv, service.env);
 }
 
 // Accepts either:


### PR DESCRIPTION
Normally, pm sets PORT to a value guaranteed to be different for each
app, so that multiple apps can be run without their ports colliding.
However, some apps may require being run on a specific port. This is
supported by doing a

    slc ctl set-env <SVC> PORT=<X>

Where X is the port that should be used. If this port is already used,
then the app will immediately crash, but that's a configuration problem
under the user's control.