### PR TITLE
Update to WS api2 of strong-control-channel

### DIFF
--- a/lib/drivers/common/control.js
+++ b/lib/drivers/common/control.js
@@ -5,17 +5,17 @@ var debug = require('debug')('strong-pm:drivers:common');
 var fmt = require('util').format;
 var os = require('os');
 
-exports.create = createControlChannel;
+exports.accept = acceptControlChannel;
 
-function createControlChannel(server, wsRouter, handler) {
+function acceptControlChannel(server, wsRouter, handler) {
   var port = server.port();
-  var channel = wsRouter.createChannel(handler);
-  var token = channel.getToken();
+  var client = wsRouter.acceptClient(handler);
+  var token = client.getToken();
   var addr = publicIp();
   var wsPath = wsRouter.path;
-  channel.url = fmt('ws://%s@%s:%d%s', token, addr, port, wsPath);
-  debug('container control socket: %s', channel.url);
-  return channel;
+  client.url = fmt('ws://%s@%s:%d%s', token, addr, port, wsPath);
+  debug('accept container control: %s', client.url);
+  return client;
 }
 
 // TODO: This should probably be configurable, but for now just grab the first

--- a/lib/drivers/direct/index.js
+++ b/lib/drivers/direct/index.js
@@ -94,8 +94,8 @@ Driver.prototype.removeInstance = function(instanceId, callback) {
 
   delete this._containers[instanceId];
 
-  if (container.channel)
-    this._wsRouter.destroyChannel(container.channel);
+  if (container.client)
+    container.client.close();
 
   container.remove(callback);
 };
@@ -131,30 +131,56 @@ Driver.prototype.instanceById = function(id) {
 Driver.prototype._containerById = function(instanceId) {
   var container = this._containers[instanceId];
 
-  if (!container) {
-    debug('create container for instance %j', instanceId);
-    var channel = control.create(this._server, this._wsRouter, onRequest);
-    container = this._containers[instanceId] = this._Container({
-      baseDir: this._baseDir,
-      console: this._console,
-      server: this._server,
-      instanceId: instanceId,
-      ctl: channel,
-      control: channel.url,
-    });
-    container.channel = channel;
-    container.instance = {
-      driverMeta: {},
-    };
+  if (container)
+    return container;
 
-    container.on('request', this.emit.bind(this, 'request', instanceId));
-  }
+  debug('create container for instance %j', instanceId);
 
-  return container;
+  // Patch in websocket channel when one is accepted.
+  var client = control.accept(this._server, this._wsRouter, onRequest);
 
   function onRequest(req, callback) {
     container.emit('request', req, callback);
   }
+
+  client.on('new-channel', function(channel) {
+    debug('new-channel on container for instance %d', instanceId);
+    if (container._channel)
+      container._channel.close();
+    container._channel = channel;
+  });
+
+  container = this._containers[instanceId] = this._Container({
+    baseDir: this._baseDir,
+    console: this._console,
+    request: request,
+    server: this._server,
+    instanceId: instanceId,
+    control: client.url,
+  });
+  container.client = client;
+
+  container.instance = {
+    driverMeta: {},
+  };
+
+  function request(req, callback) {
+    if (!container._channel) {
+      setImmediate(function() {
+        callback(new Error('no current application'));
+      });
+    } else {
+      container._channel.request(req, callback);
+    }
+  }
+
+  // XXX(sam) It seems strange that requests are emitted on container above, and
+  // then listened on here, but its because container self-listens on request
+  // events to simulate exit events. That code could probably be moved from the
+  // container to here, but I'll leave that for a later refactor.
+  container.on('request', this.emit.bind(this, 'request', instanceId));
+
+  return container;
 };
 
 Driver.prototype._onRequest = function(instanceId, req) {

--- a/lib/drivers/docker/container.js
+++ b/lib/drivers/docker/container.js
@@ -25,7 +25,14 @@ function Container(image, instance, logger, startOpts) {
   this.env = startOpts.env;
   this.onMessage = this._proxyRequest.bind(this);
   this.name = fmt('sl-pm-%s-%s', instance.id, this.commit.hash);
-  this.ctl = this.instance.channel;
+  this.instance.client.on('new-channel', function(channel) {
+    // We have a new connection, so the supervisor restarted (or two supervisors
+    // are illegally using the same token!).
+    if (instance.channel) {
+      instance.channel.close();
+    }
+    self.ctl = instance.channel = channel;
+  });
   this.instance.on('request', this.onMessage);
   this.on('created', function() {
     setImmediate(function() {

--- a/lib/drivers/docker/index.js
+++ b/lib/drivers/docker/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
+var assert = require('assert');
 var async = require('async');
 var control = require('../common/control');
 var debug = require('debug')('strong-pm:docker:driver');
@@ -297,6 +298,7 @@ DockerDriver.prototype.start = function(instanceMetas, cb) {
 
   function getInfo(next) {
     self.docker.info(function(err, info) {
+      assert.ifError(err);
       self.dockerInfo = info;
       self.CPUS = info.NCPU;
       debug('Connected to docker:', err, info);

--- a/lib/drivers/docker/index.js
+++ b/lib/drivers/docker/index.js
@@ -85,14 +85,13 @@ DockerDriver.prototype.setStartOptions = function(id, opts) {
 DockerDriver.prototype.removeInstance = function(id, cb) {
   debug('removeInstance(%j)', id);
   var instance = this._instance(id);
-  var self = this;
   if (instance.current) {
     instance.current.kill(function(err) {
       instance.current.destroy();
       delete instance.current;
       delete this._instances[id];
-      if (instance.channel) {
-        self._wsRouter.destroyChannel(instance.channel);
+      if (instance.client) {
+        instance.client.close();
       }
       cb(err);
     });
@@ -388,9 +387,9 @@ DockerDriver.prototype._instance = function(id) {
       driverMeta: {},
       svcDir: path.resolve(this.baseDir, 'svc', String(id)),
     });
-    var channel = control.create(this.server, this._wsRouter, onRequest);
-    instance.channel = channel;
-    instance.startOpts.control = channel.url;
+    var client = control.accept(this.server, this._wsRouter, onRequest);
+    instance.client = client;
+    instance.startOpts.control = client.url;
     this._instances[id] = instance;
   }
   return this._instances[id];

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "strong-fork-cicada": "^1.1.2",
     "strong-mesh-models": "^8.0.0",
     "strong-npm-ls": "^1.0.0",
-    "strong-runner": "^3.0.0",
+    "strong-runner": "^4.x",
     "strong-service-install": "^2.0.0",
     "strong-spawn-npm": "^1.0.0",
     "strong-tunnel": "^1.1.1",

--- a/test/test-docker-driver.js
+++ b/test/test-docker-driver.js
@@ -17,7 +17,7 @@ var mockServer = {
   port: _.constant(0),
 };
 var mockRouter = {
-  createChannel: _.constant({
+  acceptClient: _.constant({
     getToken: _.constant('abc'),
   }),
   path: '/test',


### PR DESCRIPTION
/to @rmg 

This partly reverts strongloop/strong-runner#11, effectively, where you inject the channel into the runner constructors. That doesn't work well with the new API. We _could_ push a `request` function in as an option, that would work better.

I reworked to use the patching of Runner approach again, which seems to work fine, though your comment on the runner PR seems to indicate that there was a problem. What was it?

I haven't run docker (or the unit tests) with this change, but I did deploy to sl-pm, and send the set-size command to the running instance, so it passes a smoke test.

I'd like some more comment before continuing.

connected to strongloop-internal/scrum-nodeops#775