### PR TITLE
Portable symlink

### DIFF
--- a/lib/drivers/common/control.js
+++ b/lib/drivers/common/control.js
@@ -20,6 +20,11 @@ function acceptControlChannel(server, wsRouter, handler) {
 
 // TODO: This should probably be configurable, but for now just grab the first
 // non-internal IPv4 address we find
+//
+// On a machine with no networking, there is no external address. Returning
+// `undefined` as the hostname goes badly, throwing an error just kills the
+// server, so soldier on with a localhost IPv4 address, which works fine on a
+// laptop with no wireless.
 function publicIp() {
   return _(os.networkInterfaces())
           .omit(['docker0', 'docker1', 'docker2'])
@@ -27,5 +32,6 @@ function publicIp() {
           .flatten()
           .where({family: 'IPv4', internal: false})
           .pluck('address')
-          .first();
+          .first()
+          || '127.0.0.1';
 }

--- a/lib/drivers/direct/container.js
+++ b/lib/drivers/direct/container.js
@@ -156,15 +156,21 @@ Container.prototype.runCurrent = function(callback) {
   var self = this;
   var currentSymlink = self.git.workdir({id: 'current'});
   self.debug('run current deployment %j', currentSymlink);
-  fs.readlink(currentSymlink, function(err, id) {
+  fs.readlink(currentSymlink, function(err, dir) {
     if (err) {
       self.debug('no current deployment found');
       return callback();
     }
 
+    // The current symlink is now absolute, but it used to be relative prior to
+    // strong-runner 5.x, so can still exist on disk as relative, both previous
+    // strong-pm installs, as well as in the unit test fixtures. Resolve it to
+    // absolute in case it isn't already.
+    dir = path.resolve(currentSymlink, '..', dir);
+
     // If we find it, it was already prepared (and run) in the past, so emit
     // it as 'prepared', after figuring out the commit metadata.
-    var dir = self.git.workdir({id: id});
+    var id = path.basename(dir);
     var hash = id.split('.')[0];
     var commit = cicadaCommit({
       dir: dir,

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "strong-fork-cicada": "^1.1.2",
     "strong-mesh-models": "^8.0.0",
     "strong-npm-ls": "^1.0.0",
-    "strong-runner": "^4.x",
+    "strong-runner": "^5.x",
     "strong-service-install": "^2.0.0",
     "strong-spawn-npm": "^1.0.0",
     "strong-tunnel": "^1.1.1",


### PR DESCRIPTION
connected to strongloop-internal/scrum-nodeops#848
depends on https://github.com/strongloop/strong-runner/pull/16