### PR TITLE
Bring back `/explorer`

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -382,7 +382,9 @@ Server.prototype.start = function start(cb) {
 
   function emitListeningSignal(serialCb) {
     debug('emitting listening event');
-    self.emit('listening', self._httpServer.address());
+    var addr = self._httpServer.address();
+    self.emit('listening', addr);
+    self._meshApp.emit('started', self.port);
     process.nextTick(serialCb);
   }
 


### PR DESCRIPTION
strongloop/strong-mesh-models@9b5468813 modified the behaviour of MeshServer to install explorer only after "started" event was fired. Because strong-pm is mounting MeshServer on its own express app, the event was never fired and the explorer was never set up.

This patch modifies strong-pm to explicitly fires "started" event on the mesh model server instance.

/to @kraman please review