### PR TITLE
test: autoskip tests requiring a license

### DIFF
--- a/test/test-server-metadata.js
+++ b/test/test-server-metadata.js
@@ -10,6 +10,7 @@ var util = require('util');
 
 var server = app.listen();
 var cpuProfilingSupported = require('semver').gt(process.version, '0.11.0');
+var notLicensed = process.env.STRONGLOOP_LICENSE ? false : 'requires license';
 
 var REPO = 'some-repo-name';
 var CTL = 'http://127.0.0.1:8701';
@@ -207,10 +208,10 @@ tap.test('cpu-start 1.1.1', pmctl('cpu-start 1.1.1'));
 tap.test('verify cpu-start', {skip: !cpuProfilingSupported}, testCpuStart);
 tap.test('cpu-stop 1.1.1', pmctl('cpu-stop 1.1.1'));
 tap.test('verify cpu-stop', {skip: !cpuProfilingSupported}, testCpuStop);
-tap.test('objects-start 1.1.1', pmctl('objects-start 1.1.1'));
-tap.test('verify objects-start', testObjTrackingStart);
-tap.test('objects-stop 1.1.1', pmctl('objects-stop 1.1.1'));
-tap.test('verify objects-stop', testObjTrackingStop);
+tap.test('objects-start 1.1.1', {skip: notLicensed}, pmctl('objects-start 1.1.1'));
+tap.test('verify objects-start', {skip: notLicensed}, testObjTrackingStart);
+tap.test('objects-stop 1.1.1', {skip: notLicensed}, pmctl('objects-stop 1.1.1'));
+tap.test('verify objects-stop', {skip: notLicensed}, testObjTrackingStop);
 tap.test('worker exit state', testWorkerExitState);
 tap.test('kill cluster master', killClusterMaster);
 tap.test('verify restart state', testRestartedInstState);


### PR DESCRIPTION
Some features require a license key, so those tests should be skipped
when one hasn't been provided.

See #289.