### PR TITLE
add --skip-default-install option

### DIFF
--- a/bin/sl-pm-install.txt
+++ b/bin/sl-pm-install.txt
@@ -27,6 +27,9 @@ Options:
                       the specified credentials for every request sent to the
                       REST API where CREDS is given in the form of
                       `<user>:<pass>`.
+  --skip-default-install
+                      Disable 'npm install' phase of application deployments
+                      made on this PM.
 
 OS Service support:
 

--- a/bin/sl-pm.js
+++ b/bin/sl-pm.js
@@ -43,6 +43,7 @@ var parser = new Parser(
     'd:(driver)',
     'l:(listen)',
     'N:(no-control)', // unused. left for backwards compat.
+    's(skip-default-install)',
     'P:(base-port)',
   ].join(''),
   argv);
@@ -76,6 +77,9 @@ while ((option = parser.getopt()) !== undefined) {
       listen = option.optarg;
       break;
     case 'N':
+      break;
+    case 's': // --skip-default-install
+      process.env.STRONGLOOP_PM_SKIP_DEFAULT_INSTALL = 'true';
       break;
     case 'P':
       basePort = option.optarg;

--- a/bin/sl-pm.txt
+++ b/bin/sl-pm.txt
@@ -10,6 +10,9 @@ Options:
   -P,--base-port PORT Applications will run at PORT + service ID (default 3000).
   --driver DRIVER     Execution backend to use for running apps. Current drivers
                       are 'direct' and 'docker' (default `direct`).
+  --skip-default-install
+                      Disable 'npm install' phase of application deployments
+                      made on this PM.
 
 The base directory is used to save deployed applications, for working
 directories, and for any other files the process manager needs to create.

--- a/lib/drivers/common/prepare.js
+++ b/lib/drivers/common/prepare.js
@@ -22,6 +22,9 @@ function _prepare(dir, env, callback) {
   debug('running %j in %j', COMMANDS, dir);
 
   var functions = COMMANDS.map(function(cmd) {
+    if (process.env.STRONGLOOP_PM_SKIP_DEFAULT_INSTALL) {
+      return skipRun(dir, env, cmd);
+    }
     return run(dir, env, cmd);
   });
 
@@ -39,6 +42,13 @@ function run(dir, env, cmd) {
       }
       return done(err);
     });
+  };
+}
+
+function skipRun(dir, env, cmd) {
+  return function(done) {
+    debug('dir %j: skipping `%j`...', dir, cmd);
+    setImmediate(done);
   };
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -37,6 +37,7 @@ function install(argv, callback) {
       'a:(http-auth)',
       'd:(driver)',
       'P:(base-port)',
+      'I(skip-default-install)',
     ].join(''),
     argv);
 
@@ -107,6 +108,9 @@ function install(argv, callback) {
       case 'a':
         jobConfig.env.STRONGLOOP_PM_HTTP_AUTH =
           auth.parse(option.optarg).normalized;
+        break;
+      case 'I': // --skip-default-install
+        jobConfig.env.STRONGLOOP_PM_SKIP_DEFAULT_INSTALL = 'true';
         break;
       default:
         console.error('Invalid usage (near option \'%s\'), try `%s --help`.',

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -74,6 +74,9 @@ assert_file $TMP/deeply/nested/sl-pm/env.json '"BAR":"foo"'
 assert_file $TMP/deeply/nested/sl-pm/env.json '"MORE":"less"'
 assert_file $TMP/deeply/nested/sl-pm/env.json '"LESS":"more"'
 
+# Should NOT have set the flag for skipping default install
+assert_not_file $TMP/upstart.conf "STRONGLOOP_PM_SKIP_DEFAULT_INSTALL"
+
 # Should fail to overwrite existing file
 assert_exit 1 $CMD --port 7777 --user $CURRENT_USER \
                    --job-file $TMP/upstart.conf \
@@ -85,10 +88,14 @@ assert_exit 0 $CMD --port 7777 \
                    --user `id -un` \
                    --base $TMP/deeply/nested/sl-pm \
                    --force \
-                   --http-auth "myuser:mypass"
+                   --http-auth "myuser:mypass" \
+                   --skip-default-install
 
 # Should add auth to config, treating "myuser:mypass" as implied Basic auth
 assert_file $TMP/upstart.conf "STRONGLOOP_PM_HTTP_AUTH=basic:myuser:mypass"
+
+# Should have set the flag for skipping default install
+assert_file $TMP/upstart.conf "STRONGLOOP_PM_SKIP_DEFAULT_INSTALL=true"
 
 # Should create an upstart job at the specified path
 assert_exit 0 $CMD --port 7777 \


### PR DESCRIPTION
In this mode, when an application is deployed to strong-pm no
installation or build actions are taken. The commit or tarball are
simply extracted to the location on disk and app is started.

This is to work with the new strong-pack based sl-build behaviour that
is optimized for deployment processes where the build is run in an
environment compatible with the production environment and allows for
even more strict production environments since it does not require a
compiler or even npm to be available at run time.

Connect to strongloop-internal/scrum-nodeops#1015