### PR TITLE
Switch to using `sqlite` as PM database

### DIFF
--- a/bin/sl-pm.txt
+++ b/bin/sl-pm.txt
@@ -13,6 +13,8 @@ Options:
   --skip-default-install
                       Disable 'npm install' phase of application deployments
                       made on this PM.
+  --json-file-db      Persist deployment information and metrics in a JSON based
+                      database. Not recommended for production use.
 
 The base directory is used to save deployed applications, for working
 directories, and for any other files the process manager needs to create.

--- a/lib/drivers/direct/container.js
+++ b/lib/drivers/direct/container.js
@@ -95,6 +95,7 @@ function Container(options) {
           id: 0,
           pid: supervisorPid,
           reason: status,
+          pst: req.pst,
         });
       });
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,7 @@ var EventEmitter = require('events').EventEmitter;
 var MeshServer = require('strong-mesh-models').meshServer;
 var MinkeLite = require('minkelite');
 var ServiceManager = require('./service-manager');
+var Sqlite3 = require('loopback-connector-sqlite3');
 var WebsocketRouter = require('strong-control-channel/ws-router');
 var assert = require('assert');
 var async = require('async');
@@ -14,6 +15,7 @@ var auth = require('./auth');
 var c2s = require('strong-runner').Runnable.toString;
 var debug = require('./debug')('server');
 var express = require('express');
+var fmt = require('util').format;
 var http = require('http');
 var mandatory = require('./util').mandatory;
 var onCtlRequest = require('./ctl');
@@ -35,6 +37,7 @@ var OPTIONS = {
   Environment: Environment,
   MeshServer: MeshServer,
   ServiceManager: ServiceManager,
+  dbDriver: 'sqlite3',
 
   // Optional:
   //   baseDir:       Defaults to '.strong-pm'
@@ -60,6 +63,7 @@ function Server(options) {
   var Environment = mandatory(options.Environment);
   var MeshServer = mandatory(options.MeshServer);
   var ServiceManager = mandatory(options.ServiceManager);
+  var dbDriver = mandatory(options.dbDriver);
 
   this._cmdName = options.cmdName || 'sl-pm';
   this._baseDir = path.resolve(options.baseDir || '.strong-pm');
@@ -68,7 +72,30 @@ function Server(options) {
   this._envPath = path.resolve(this._baseDir, 'env.json');
   this._defaultEnv = new Environment(this._envPath);
 
-  var meshOptions = {};
+  this._dataSourceConfig = null;
+  switch (dbDriver) {
+    case 'sqlite3':
+      this._dataSourceConfig = {
+        connector: Sqlite3,
+        file: options['mesh.db.filePath'] ||
+          path.join(this._baseDir, 'strong-mesh.db'),
+      };
+      break;
+    case 'memory':
+      this._dataSourceConfig = {
+        connector: 'memory',
+        file: process.env.STRONGLOOP_MESH_DB ||
+          path.join(this._baseDir, 'strong-mesh.json'),
+      };
+      break;
+    default:
+      throw new Error(fmt('data source %s not supported.', dbDriver));
+  }
+
+  var meshOptions = {
+    db: this._dataSourceConfig,
+  };
+
   /* eslint-disable camelcase */
   // Instantiate minkelite so trace data can be stored
   this._minkelite = new MinkeLite({
@@ -88,12 +115,6 @@ function Server(options) {
       10) || 30,
   });
   /* eslint-enable camelcase */
-
-  if (!process.env.STRONGLOOP_MESH_DB) {
-    process.env.STRONGLOOP_MESH_DB =
-      'memory://' + path.join(this._baseDir, 'strong-pm.json');
-  }
-  debug('Using STRONGLOOP_MESH_DB=%s', process.env.STRONGLOOP_MESH_DB);
 
   // The express app on which the rest of the middleware is mounted.
   this._baseApp = express();
@@ -323,9 +344,9 @@ Server.prototype.start = function start(cb) {
   var self = this;
 
   async.series([
-    appListen,
     parentIpcListen,
     initOrUpdateDb,
+    appListen,
     startDriver,
     emitListeningSignal,
   ], done);

--- a/lib/service-manager.js
+++ b/lib/service-manager.js
@@ -83,14 +83,18 @@ prototype.initOrUpdateDb = function(meshApp, callback) {
     return env;
   };
 
-  Executor.findById('1', function(err, executor) {
+  this._meshApp.dataSources.db.autoupdate(function(err) {
     if (err) return callback(err);
-    if (!executor) {
-      return self._initDb(stopStaleProcesses);
-    }
 
-    executor.APIPort = self._listenPort;
-    executor.save(stopStaleProcesses);
+    Executor.findById('1', function(err, executor) {
+      if (err) return callback(err);
+      if (!executor) {
+        return self._initDb(stopStaleProcesses);
+      }
+
+      executor.APIPort = self._listenPort;
+      executor.save(stopStaleProcesses);
+    });
   });
 
   function stopStaleProcesses(err) {

--- a/lib/upgrade-db.js
+++ b/lib/upgrade-db.js
@@ -1,0 +1,74 @@
+'use strict';
+
+var MeshServer = require('strong-mesh-models').meshServer;
+var MeshServiceManager = require('strong-mesh-models').ServiceManager;
+var SQLite3 = require('loopback-connector-sqlite3');
+var async = require('async');
+var debug = require('debug')('upgrade-db');
+var fs = require('fs');
+var path = require('path');
+
+module.exports = tryUpgradeDb;
+
+function tryUpgradeDb(baseDir, memoryDbPath, dryRun, callback) {
+  var meshDbPath = path.join(baseDir, 'strong-mesh.db');
+  fs.stat(meshDbPath, function(err) {
+    debug('Ensuring %s doesn\'t exist', meshDbPath);
+    if (!err) {
+      debug('Error: %s exist', meshDbPath);
+      return callback(new Error('Database ' + meshDbPath + ' already exists'));
+    }
+
+    upgradeDb(memoryDbPath, meshDbPath, function(err) {
+      if (err) {
+        debug('Upgrade failed Removing db: %s', meshDbPath);
+        return fs.unlink(meshDbPath, function(uerr) {
+          if (uerr) {
+            debug('Unable to remove database', uerr);
+          }
+          callback(err);
+        });
+      }
+      if (dryRun) {
+        debug('Cleaning out %s (dry-run).', meshDbPath);
+        return fs.unlink(meshDbPath, callback);
+      } else {
+        debug('Cleaning out %s.', memoryDbPath);
+        return fs.unlink(memoryDbPath, callback);
+      }
+    });
+  });
+}
+
+function upgradeDb(memoryDbPath, meshDbPath, callback) {
+  var meshOptions = {
+    db: {
+      connector: SQLite3,
+      file: meshDbPath,
+    },
+  };
+  var meshApp = MeshServer(new MeshServiceManager(), null, meshOptions);
+
+  try {
+    var data = JSON.parse(fs.readFileSync(memoryDbPath, 'utf8'));
+  } catch (err) {
+    debug('Source database %s missing or invalid', memoryDbPath);
+    return callback(err);
+  }
+  var models = Object.keys(data.ids);
+
+  meshApp.dataSources.db.autoupdate(function(err) {
+    if (err) return callback(err);
+
+    async.each(models, function(modelName, callback) {
+      var modelData = data.models[modelName];
+
+      var ModelCtor = meshApp.dataSources.db.models[modelName];
+      async.each(Object.keys(modelData), function(id, callback) {
+        var data = JSON.parse(modelData[id]);
+        var model = new ModelCtor(data);
+        model.save(callback);
+      }, callback);
+    }, callback);
+  });
+};

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "extsprintf": "^1.2.0",
     "http-auth": "^2.2.5",
     "lodash": "^3.9.3",
+    "loopback-connector-sqlite3": "^1.0.0",
     "minkelite": "^1.0.0",
     "mkdirp": "^0.5.0",
     "posix-getopt": "^1.0.0",

--- a/test/test-server-env.js
+++ b/test/test-server-env.js
@@ -1,5 +1,4 @@
 process.env.STRONGLOOP_LICENSE = 'inherited';
-process.env.STRONGLOOP_MESH_DB = 'memory://';
 
 var Server = require('../lib/server');
 var mktmpdir = require('mktmpdir');
@@ -25,21 +24,20 @@ function matchEnv(tt, env, expectedEnv) {
 }
 
 test('service environment', function(t) {
-  mktmpdir(function(err, tmpdir, cleanup) {
-    t.ifError(err);
-    t.on('end', cleanup);
+  function MockDriver(o) {
+    this.options = o;
+  }
+  MockDriver.prototype.getName = _.constant('Mock');
+  MockDriver.prototype.on = function() {};
+  MockDriver.prototype.setStartOptions = function() {};
+  MockDriver.prototype.stop = function(callback) {
+    callback();
+  };
 
-    function MockDriver(o) {
-      this.options = o;
-    }
-    MockDriver.prototype.getName = _.constant('Mock');
-    MockDriver.prototype.on = function() {};
-    MockDriver.prototype.setStartOptions = function() {};
-    MockDriver.prototype.stop = function(callback) {
-      callback();
-    };
-
-    t.test('empty initial environment', function(tt) {
+  t.test('empty initial environment', function(tt) {
+    mktmpdir(function(err, tmpdir, cleanup) {
+      tt.ifError(err);
+      tt.on('end', cleanup);
       fs.writeFileSync(path.join(tmpdir, 'env.json'), '{}');
 
       var s = new Server({
@@ -69,8 +67,12 @@ test('service environment', function(t) {
         });
       });
     });
+  });
 
-    t.test('initial environment', function(tt) {
+  t.test('initial environment', function(tt) {
+    mktmpdir(function(err, tmpdir, cleanup) {
+      tt.ifError(err);
+      tt.on('end', cleanup);
       var defEnv = {FOO: 'foo', BAR: 'bar'};
       var newEnv = {BAR: 'bar'};
       fs.writeFileSync(path.join(tmpdir, 'env.json'), JSON.stringify(defEnv));
@@ -115,7 +117,7 @@ test('service environment', function(t) {
         });
       }
     });
-
-    t.end();
   });
+
+  t.end();
 });

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -1,365 +1,208 @@
+var EventEmitter = require('events').EventEmitter;
+var Server = require('../lib/server');
 var _ = require('lodash');
 var assert = require('assert');
 var async = require('async');
 var debug = require('debug')('strong-pm:test');
-var EventEmitter = require('events').EventEmitter;
-var path = require('path');
-var Server = require('../lib/server');
+var mktmpdir = require('mktmpdir');
 var tap = require('tap');
 var util = require('util');
 
-var BASE = path.resolve(__dirname, '.strong-pm');
-process.env.STRONGLOOP_MESH_DB = 'memory://';
-
 tap.test('server test', function(t) {
-// t.test('full server construction', function(tt) {
-//  var server = new Server({
-//    cmdName: 'pm',
-//    baseDir: BASE,
-//    listenPort: 0,
-//  });
-//  server.stop(tt.end.bind(tt));
-// });
-//
-// t.test('mocked server construction', function(tt) {
-//  var driver;
-//  function MockDriver(o) {
-//    this.options = o;
-//    driver = this;
-//  };
-//
-//  MockDriver.prototype.on = function(event) {
-//    var wanted = 'request or listening';
-//    if (event === 'request' || event === 'listening') {
-//      wanted = event;
-//    }
-//    tt.equal(event, wanted, 'event handler must be registered');
-//  };
-//
-//  MockDriver.prototype.stop = function(callback) {
-//    callback();
-//  };
-//
-//  var serviceManager;
-//  function MockServiceManager(o) {
-//    this.options = o;
-//    this.handle = function(req,res,next) {};
-//    serviceManager = this;
-//  }
-//
-//  var server;
-//  function MockMeshServerFactory(_serviceManager, minkelite,  o) {
-//    tt.equal(_serviceManager, serviceManager, 'service manager must match');
-//    tt.deepEqual(o, {}, 'mesh server options must match');
-//    server = function(req, res, next) {};
-//    return server;
-//  }
-//
-//  var options = {
-//    cmdName: 'pm',
-//    baseDir: BASE,
-//    listenPort: 0,
-//    Driver: MockDriver,
-//    ServiceManager: MockServiceManager,
-//    MeshServer: MockMeshServerFactory
-//  };
-//
-//  tt.plan(7);
-//
-//  var s = new Server(options);
-//  tt.equal(driver.options.baseDir, options.baseDir, 'base dir must match');
-//  tt.equal(driver.options.server, s, 'driver.server must match');
-//  tt.equal(serviceManager.options, s,
-//    'serviceManager options must match');
-//  s.stop(tt.end.bind(tt));
-// });
-//
-// t.test('driver methods are forwarded', function(tt) {
-//  var startOptions = {};
-//  var req = {};
-//  var res = {};
-//
-//  var svcId = 10;
-//  var instId = 10;
-//
-//  function MockDriver(o) {
-//    this.options = o;
-//    driver = this;
-//  }
-//
-//  MockDriver.prototype.getName = _.constant('Mock');
-//
-//  MockDriver.prototype.on = function(event) {
-//    var wanted = 'request or listening';
-//    if (event === 'request' || event === 'listening') {
-//      wanted = event;
-//    }
-//    tt.equal(event, wanted, 'event handler must be registered');
-//  };
-//
-//  MockDriver.prototype.setStartOptions = function(_instId, _startOptions) {
-//    tt.equal(_instId, instId, 'setStartOptions: instId must match');
-//    tt.equal(_startOptions, startOptions,
-//      'setStartOptions: start actions must match');
-//  };
-//
-//  MockDriver.prototype.deployInstance = function(_instId, _req, _res) {
-//    tt.equal(_instId, instId, 'deployInstance: instId must match');
-//    tt.equal(_req, req, 'deployInstance: req must match');
-//    tt.equal(_res, res, 'deployInstance: res must match');
-//  };
-//
-//  MockDriver.prototype.dumpInstanceLog = function(_instId) {
-//    tt.equal(_instId, instId, 'dumpInstanceLog: instId must match');
-//    return 'LOG';
-//  };
-//
-//  MockDriver.prototype.startInstance = function(_instId, callback) {
-//    tt.equal(_instId, instId, 'startInstance: instId must match');
-//    setImmediate(callback);
-//  };
-//
-//  MockDriver.prototype.stopInstance = function(_instId, callback) {
-//    tt.equal(_instId, instId, 'stopInstance: instId must match');
-//    setImmediate(callback);
-//  };
-//
-//  MockDriver.prototype.stop = function(callback) {
-//    callback();
-//  };
-//
-//  var serviceManager;
-//  function MockServiceManager(o) {
-//    this.options = o;
-//    this.handle = function(req,res,next) {};
-//    serviceManager = this;
-//  }
-//
-//  var server;
-//  function MockMeshServerFactory(_serviceManager, minkelite, o) {
-//    tt.equal(_serviceManager, serviceManager, 'service manager must match');
-//    server = function(req, res, next) {};
-//    return server;
-//  }
-//
-//  var options = {
-//    cmdName: 'pm',
-//    baseDir: BASE,
-//    listenPort: 0,
-//    enableTracing: true,
-//    Driver: MockDriver,
-//    ServiceManager: MockServiceManager,
-//    MeshServer: MockMeshServerFactory
-//  };
-//
-//  tt.plan(11);
-//
-//  var s = new Server(options);
-//  s.setStartOptions(svcId, startOptions);
-//  s.deployInstance(instId, req, res);
-//  tt.equal(s.dumpInstanceLog(instId), 'LOG',
-//    'dumpInstanceLog: log must match');
-//
-//  // TODO cover the rest of the methods. Could also cover the error branches,
-//  // I wish I had code coverage metrics :-(
-//  async.series([
-//    s.startInstance.bind(s, instId),
-//    s.stopInstance.bind(s, instId),
-//  ], function() {
-//    s.stop(tt.end.bind(tt));
-//  });
-// });
+  mktmpdir(function(err, tmpdir, done) {
+    t.ifError(err);
+    // t.on('end', done);
+    var BASE = tmpdir;
+    console.log(BASE);
 
-// XXX(sam) test below needs re-writing into a unit test against public APIs,
-// right now it depends on private methods of Driver, Container, and
-// ServiceManager.
+  // XXX(sam) test below needs re-writing into a unit test against public APIs,
+  // right now it depends on private methods of Driver, Container, and
+  // ServiceManager.
 
-  t.test('service starts', function(tt) {
-    var svcId = -1;
-    var instId = -1;
-    var commit = {hash: '123', dir: '/some/dir'};
+    t.test('service starts', function(tt) {
+      var svcId = -1;
+      var instId = -1;
+      var commit = {hash: '123', dir: '/some/dir'};
 
-    function MockContainer() {
-      this.current = {};
-      this.current.commit = commit;
-    }
-    MockContainer.prototype.request = function request(req, cb) {
-      if (req.cmd === 'status') {
-        cb({master: {setSize: 1}});
+      function MockContainer() {
+        this.current = {};
+        this.current.commit = commit;
       }
-      if (req.cmd === 'npm-ls') {
-        cb({});
-      }
-    };
+      MockContainer.prototype.request = function request(req, cb) {
+        if (req.cmd === 'status') {
+          cb({master: {setSize: 1}});
+        }
+        if (req.cmd === 'npm-ls') {
+          cb({});
+        }
+      };
 
-    function MockDriver(o) {
-      this.options = o;
-      EventEmitter.call(this);
-      this._containers = {};
-    }
-    util.inherits(MockDriver, EventEmitter);
-    MockDriver.prototype.getName = _.constant('Mock');
-    MockDriver.prototype.start = function(callback) {
-      this.emit('request', instId, {
-        cmd: 'started',
-        appName: 'test-app',
-        agentVersion: '1.0.0',
-        wid: 0,
-        pid: 1234,
-        pst: Date.now(),
-      });
-      callback();
-    };
-    MockDriver.prototype.instanceById = function() {
-      return this._containerById(instId).current;
-    };
-    MockDriver.prototype._containerById = function(instanceId) {
-      var container = this._containers[instanceId];
-      if (!container) {
-        container = this._containers[instanceId] = new MockContainer();
+      function MockDriver(o) {
+        this.options = o;
+        EventEmitter.call(this);
+        this._containers = {};
       }
-      return container;
-    };
-    MockDriver.prototype.requestOfInstance = function(instanceId, req, cb) {
-      var container = this._containerById(instId);
-      container.request(req, cb);
-    };
-    MockDriver.prototype.updateInstanceEnv =
-      function(instanceId, env, callback) {
+      util.inherits(MockDriver, EventEmitter);
+      MockDriver.prototype.getName = _.constant('Mock');
+      MockDriver.prototype.start = function(callback) {
+        this.emit('request', instId, {
+          cmd: 'started',
+          appName: 'test-app',
+          agentVersion: '1.0.0',
+          wid: 0,
+          pid: 1234,
+          pst: Date.now(),
+        });
         callback();
       };
-    MockDriver.prototype.setStartOptions = function() {};
-    MockDriver.prototype.stop = function(callback) {
-      callback();
-    };
-
-    var options = {
-      cmdName: 'pm',
-      baseDir: BASE,
-      listenPort: 1234,
-      enableTracing: false,
-      Driver: MockDriver,
-    };
-
-    var s = new Server(options);
-    var m = s._meshApp.models;
-    var serviceManager = s._serviceManager;
-
-    // Make server think its running.
-    s._isStarted = true;
-    async.series([
-      serviceManager.initOrUpdateDb.bind(serviceManager, s._meshApp),
-      createService,
-      findInstance,
-      firstRun,
-      checkInstance,
-      secondRun,
-      checkInstance,
-      end,
-    ], function() {
-      s.stop(tt.end.bind(tt));
-    });
-
-    function createService(callback) {
-      debug('create service');
-      m.ServerService.create({
-        name: 'default',
-        _groups: [m.Group({name: 'default', id: 1, scale: 1})],
-      }, function(err, service) {
-        tt.ifError(err, 'create svc');
-        svcId = service.id;
-
-        // Use setImmediate instead of nextTick so that hooks are run before
-        // callback is invoked
-        setImmediate(callback);
-      });
-    }
-
-    function findInstance(callback) {
-      m.ServiceInstance.findOne(
-        {where: {serverServiceId: svcId}},
-        function(err, inst) {
-          tt.ifError(err, 'find svc');
-          instId = inst.id;
-          debug('instance assigned. Id: %s', instId);
-          callback();
+      MockDriver.prototype.instanceById = function() {
+        return this._containerById(instId).current;
+      };
+      MockDriver.prototype._containerById = function(instanceId) {
+        var container = this._containers[instanceId];
+        if (!container) {
+          container = this._containers[instanceId] = new MockContainer();
         }
-      );
-    }
+        return container;
+      };
+      MockDriver.prototype.requestOfInstance = function(instanceId, req, cb) {
+        var container = this._containerById(instId);
+        container.request(req, cb);
+      };
+      MockDriver.prototype.updateInstanceEnv =
+        function(instanceId, env, callback) {
+          callback();
+        };
+      MockDriver.prototype.setStartOptions = function() {};
+      MockDriver.prototype.stop = function(callback) {
+        callback();
+      };
 
-    function firstRun(callback) {
-      s._driver.start(function(err) {
-        if (err) return callback(err);
+      var options = {
+        cmdName: 'pm',
+        baseDir: BASE,
+        listenPort: 1234,
+        enableTracing: false,
+        Driver: MockDriver,
+      };
 
-        // Use setImmediate instead of nextTick so that hooks are run before
-        // callback is invoked
-        setImmediate(callback.bind(null, err));
+      var s = new Server(options);
+      var m = s._meshApp.models;
+      var serviceManager = s._serviceManager;
+
+      // Make server think its running.
+      s._isStarted = true;
+      async.series([
+        serviceManager.initOrUpdateDb.bind(serviceManager, s._meshApp),
+        createService,
+        findInstance,
+        firstRun,
+        checkInstance,
+        secondRun,
+        checkInstance,
+        end,
+      ], function() {
+        s.stop(tt.end.bind(tt));
       });
-    }
 
-    function secondRun(callback) {
-      debug('second run');
-      commit = {hash: 'hash2', dir: 'dir2'};
+      function createService(callback) {
+        debug('create service');
+        m.ServerService.create({
+          name: 'default',
+          _groups: [m.Group({name: 'default', id: 1, scale: 1})],
+        }, function(err, service) {
+          tt.ifError(err, 'create svc');
+          svcId = service.id;
 
-      // remove old container so new one is created
-      s._driver._containers = {};
+          // Use setTimeout so that hooks are run before callback is invoked
+          setTimeout(callback, 1000);
+        });
+      }
 
-      s._driver.start(function(err) {
-        // Use setImmediate instead of nextTick so that hooks are run before
-        // callback is invoked
-        setImmediate(callback.bind(null, err));
-      });
-    }
+      function findInstance(callback) {
+        m.ServiceInstance.findOne(
+          {where: {serverServiceId: svcId}},
+          function(err, inst) {
+            tt.ifError(err, 'find svc');
+            instId = inst.id;
+            debug('instance assigned. Id: %s', instId);
+            callback();
+          }
+        );
+      }
 
-    function checkInstance(callback) {
-      m.ServiceInstance.findById(instId, function(err, _inst) {
-        debug('instance: %j', _inst);
-        assert.ifError(err);
-        tt.equal(_inst.id, instId);
-        tt.equal(_inst.executorId, 1);
-        tt.equal(_inst.serverServiceId, svcId);
-        tt.equal(_inst.groupId, 1);
-        tt.equal(_inst.currentDeploymentId, commit.hash);
-        tt.assert(_inst.startTime < new Date());
-        tt.equal(s._listenPort, 1234);
-        tt.equal(_inst.PMPort, s._listenPort);
+      function firstRun(callback) {
+        s._driver.start(function(err) {
+          if (err) return callback(err);
 
-        m.ServerService.findById(svcId, function(err, _srv) {
-          debug('service: %j', _srv);
+          // Use setTimeout so that hooks are run before callback is invoked
+          setTimeout(callback.bind(null, err), 1000);
+        });
+      }
+
+      function secondRun(callback) {
+        debug('second run');
+        commit = {hash: 'hash2', dir: 'dir2'};
+
+        // remove old container so new one is created
+        s._driver._containers = {};
+
+        s._driver.start(function(err) {
+          // Use setTimeout so that hooks are run before callback is invoked
+          setTimeout(callback.bind(null, err), 1000);
+        });
+      }
+
+      function checkInstance(callback) {
+        m.ServiceInstance.findById(instId, function(err, _inst) {
+          debug('instance: %j', _inst);
           assert.ifError(err);
-          tt.equal(_srv.id, 1);
+          tt.equal(_inst.id, instId);
+          tt.equal(_inst.executorId, 1);
+          tt.equal(_inst.serverServiceId, svcId);
+          tt.equal(_inst.groupId, 1);
+          tt.equal(_inst.currentDeploymentId, commit.hash);
+          tt.assert(_inst.startTime < new Date());
+          tt.equal(s._listenPort, 1234);
+          tt.equal(_inst.PMPort, s._listenPort);
 
-          tt.equal(_srv.deploymentInfo.hash, commit.hash);
-          tt.equal(_srv.deploymentInfo.dir, commit.dir);
+          m.ServerService.findById(svcId, function(err, _srv) {
+            debug('service: %j', _srv);
+            assert.ifError(err);
+            tt.equal(_srv.id, 1);
+
+            tt.equal(_srv.deploymentInfo.hash, commit.hash);
+            tt.equal(_srv.deploymentInfo.dir, commit.dir);
+            callback();
+          });
+        });
+      }
+
+      function end(callback) {
+        var tasks = {
+          ServerService: 0,
+          Executor: 0,
+          ServiceInstance: 0,
+          Group: 0,
+        };
+        Object.keys(tasks).forEach(function(type) {
+          tasks[type] = function(callback) {
+            m[type].count(callback);
+          };
+        });
+
+        async.parallel(tasks, function(counts) {
+          debug('counts: %j', counts);
+
+          for (var type in counts) {
+            tt.equal(counts[type], 1, type);
+          }
+
           callback();
         });
-      });
-    }
+      }
+    });
 
-    function end(callback) {
-      var tasks = {
-        ServerService: 0,
-        Executor: 0,
-        ServiceInstance: 0,
-        Group: 0,
-      };
-      Object.keys(tasks).forEach(function(type) {
-        tasks[type] = function(callback) {
-          m[type].count(callback);
-        };
-      });
-
-      async.parallel(tasks, function(counts) {
-        debug('counts: %j', counts);
-
-        for (var type in counts) {
-          tt.equal(counts[type], 1, type);
-        }
-
-        callback();
-      });
-    }
+    t.end();
   });
-
-  t.end();
 });


### PR DESCRIPTION
* sqlite is now default.
* can still use memory db using `--in-memory-db` option.
* install script will upgrade from memory to sqlite3 if needed.

Connect to strongloop-internal/scrum-nodeops#964