### PR TITLE
Make sqlite an optional PM dependency

### DIFF
--- a/bin/sl-pm.js
+++ b/bin/sl-pm.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-var upgradeDb = require('../lib/upgrade-db');
-
 // Exit on loss of parent process, if it had established an ipc control channel.
 // We do this ASAP because we don't want child processes to leak, outliving
 // their parent. If the parent has not established an 'ipc' channel to us, this
@@ -115,6 +113,17 @@ mkdirp(base);
 process.chdir(base);
 
 if (dbDriver === 'sqlite3') {
+  try {
+    // sqlite connector is an optional dependency. If we're unable to load it
+    // throw a meaningful error here.
+    require('loopback-connector-sqlite3');
+    var upgradeDb = require('../lib/upgrade-db');
+  } catch (err) {
+    console.error('loopback-connector-sqlite3 must be installed to use the ' +
+      'sql backend. Use the --json-file-db option if you are unable to ' +
+      'install loopback-connector-sqlite3.');
+    return process.exit(1);
+  }
   checkAndUpgradeDb(base, function(err) {
     if (err) {
       console.error('%s(%d) %s', $0, process.pid, err.message);

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,7 +7,6 @@ var EventEmitter = require('events').EventEmitter;
 var MeshServer = require('strong-mesh-models').meshServer;
 var MinkeLite = require('minkelite');
 var ServiceManager = require('./service-manager');
-var Sqlite3 = require('loopback-connector-sqlite3');
 var WebsocketRouter = require('strong-control-channel/ws-router');
 var assert = require('assert');
 var async = require('async');
@@ -75,8 +74,9 @@ function Server(options) {
   this._dataSourceConfig = null;
   switch (dbDriver) {
     case 'sqlite3':
+      // delay requiring loopback-connector-sqlite3 as it's an optional dep
       this._dataSourceConfig = {
-        connector: Sqlite3,
+        connector: require('loopback-connector-sqlite3'),
         file: options['mesh.db.filePath'] ||
           path.join(this._baseDir, 'strong-mesh.db'),
       };

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "extsprintf": "^1.2.0",
     "http-auth": "^2.2.5",
     "lodash": "^3.9.3",
-    "loopback-connector-sqlite3": "^1.0.0",
     "minkelite": "^1.0.0",
     "mkdirp": "^0.5.0",
     "posix-getopt": "^1.0.0",
@@ -87,5 +86,8 @@
     "strong-url-defaults": "^1.0.0",
     "tar": "^1.0.0",
     "userhome": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "loopback-connector-sqlite3": "^1.0.0"
   }
 }

--- a/test/test-sl-pm-missing-sql-dep.js
+++ b/test/test-sl-pm-missing-sql-dep.js
@@ -1,0 +1,71 @@
+'use strict';
+
+var async = require('async');
+var exec = require('child_process').exec;
+var fmt = require('util').format;
+var fs = require('fs');
+var home = require('userhome');
+var path = require('path');
+var rimraf = require('rimraf');
+var test = require('tap').test;
+
+var script = path.join(__dirname, '..', 'bin', 'sl-pm.js');
+var moduleDir = path.dirname(require.resolve('loopback-connector-sqlite3'));
+var tempDir = fmt('%s_tmp', moduleDir);
+var base = home('.strong-pm');
+
+test('test setup', function(t) {
+  function rename(cb) {
+    fs.rename(moduleDir, tempDir, function(err, res) {
+      t.ifErr(err, 'Should not get an error renaming directories');
+      try {
+        require('loopback-connector-sqlite3');
+        t.fail('Should not have been able to load loopback-connector-sqlite3');
+      } catch (err) {
+        t.ok('Got an error trying to require loopback-connector-sqlite3');
+      }
+      cb();
+    });
+  };
+  async.parallel([rename, rimraf.bind(null, base)], t.end);
+});
+
+test('invoke sl-pm missing sqllite dep', function(t) {
+  var cmd = ['node', script];
+  exec(cmd.join(' '), function(err, stdOut, stdErr) {
+    t.ok(err);
+    t.equals(err.code, 1);
+    t.equals(stdErr, 'loopback-connector-sqlite3 must be installed to ' +
+      'use the sql backend. Use the --json-file-db option if you are unable ' +
+      'to install loopback-connector-sqlite3.\n');
+
+    t.end();
+  });
+});
+
+test('invoke sl-pm --json-file-db', function(t) {
+  var cmd = ['node', script, '--json-file-db'].join(' ');
+  var child = exec(cmd, { timeout: 30000 }, function(err, stdOut, stdErr) {
+    t.ok(err);
+    t.ok(err.signal);
+    t.equals(err.signal, 'SIGQUIT');
+    t.end();
+  });
+
+  var buffered = '';
+  child.stdout.on('data', function(data) {
+    buffered += data;
+
+    if (buffered.match(/Browse your REST API/)) {
+      t.comment('Found `Browse your REST API` stdout.');
+      child.kill('SIGQUIT');
+    }
+  });
+});
+
+test('test cleanup', function(t) {
+  fs.rename(tempDir, moduleDir, function(err, res) {
+    t.ifErr(err, 'Should not get an error renaming directories');
+    t.end();
+  });
+});


### PR DESCRIPTION
strongloop/strong-pm#299 updated strong-pm to use sqlite, but that breaks platforms / machines that don't have sqlite installed.

This PR makes the sqlite dependency optional and handles the missing dep at runtime if `--json-file-db` is provided.