### PR TITLE
Update pm error message when db upgrade fails.

### DIFF
--- a/bin/sl-pm.js
+++ b/bin/sl-pm.js
@@ -121,7 +121,8 @@ if (dbDriver === 'sqlite3') {
   } catch (err) {
     console.error('loopback-connector-sqlite3 must be installed to use the ' +
       'sql backend. Use the --json-file-db option if you are unable to ' +
-      'install loopback-connector-sqlite3.');
+      'install loopback-connector-sqlite3. Error encountered while trying ' +
+      'to upgrade: [ %s ]', err.message);
     return process.exit(1);
   }
   checkAndUpgradeDb(base, function(err) {

--- a/test/test-sl-pm-missing-sql-dep.js
+++ b/test/test-sl-pm-missing-sql-dep.js
@@ -37,7 +37,8 @@ test('invoke sl-pm missing sqllite dep', function(t) {
     t.equals(err.code, 1);
     t.equals(stdErr, 'loopback-connector-sqlite3 must be installed to ' +
       'use the sql backend. Use the --json-file-db option if you are unable ' +
-      'to install loopback-connector-sqlite3.\n');
+      'to install loopback-connector-sqlite3. Error encountered while trying ' +
+      'to upgrade: [ Cannot find module \'loopback-connector-sqlite3\' ]\n');
 
     t.end();
   });


### PR DESCRIPTION
Connected to strongloop/strong-pm#336

````
$ node bin/sl-pm.js 
loopback-connector-sqlite3 must be installed to use the sql backend. Use the --json-file-db option if you are unable to install loopback-connector-sqlite3. Error encountered while trying to upgrade: [ Cannot find module 'loopback-connector-sqlite3' ]
````