### PR TITLE
test: update docker tests to use official node

### DIFF
--- a/test/Dockerfile.in
+++ b/test/Dockerfile.in
@@ -1,22 +1,16 @@
-FROM nodesource/node:trusty
-
-RUN apt-get install -yq git && apt-get clean
-# RUN node-gyp install
+FROM node:0.10
 
 # Create "strongloop" user
-RUN useradd -ms /bin/bash strongloop
-# && chown -R strongloop /usr/local
-# Let everyone run sudo without a password (dangerous!)
-RUN echo "ALL	ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN useradd -ms /bin/bash strongloop \
+ && chown -R strongloop /usr/local
 
 # Set up some semblance of an environment
 WORKDIR /home/strongloop
 ENV HOME /home/strongloop
 USER strongloop
-RUN node-gyp install && npm cache clear
 
 # actual work..
 COPY strong-pm.tgz /home/strongloop/
-RUN sudo npm install --registry NPM_CONFIG_REGISTRY --global strong-pm.tgz
+RUN npm install --registry NPM_CONFIG_REGISTRY --global strong-pm.tgz
 
-ENTRYPOINT ["/usr/bin/sl-pm"]
+ENTRYPOINT ["/usr/local/bin/sl-pm"]

--- a/test/test-e2e-docker.sh
+++ b/test/test-e2e-docker.sh
@@ -38,8 +38,9 @@ docker_run() {
 
   # trap "docker stop $SL_PM; kill $LOGGER" EXIT
 
-  if which boot2docker > /dev/null; then
-    LOCALHOST=$(boot2docker ip 2> /dev/null)
+  if test -n "$DOCKER_HOST"; then
+    LOCALHOST=${DOCKER_HOST##*/}
+    LOCALHOST=${LOCALHOST%%:*}
   else
     LOCALHOST="127.0.0.1"
   fi


### PR DESCRIPTION
When these tests were written there was no official node image. Now the
nodesource image no longer provides the image that was originally used.

Simple fix is to just tweak the Dockerfile to use a different image, and
adjust for it.

Note that this is mostly to unblock upstream builds.