### PR TITLE
test: make install tests with docker optional

### DIFF
--- a/test/test-e2e-docker.sh
+++ b/test/test-e2e-docker.sh
@@ -4,8 +4,8 @@ set -e
 cd $(dirname "${BASH_SOURCE[0]}")
 source common.sh
 
-if ! docker info > /dev/null; then
-  skip "docker not installed or not running"
+if ! docker info > /dev/null || docker info | grep swarm > /dev/null; then
+  skip "docker not installed or not running, or swarm detected"
   exit
 fi
 

--- a/test/test-install-systemd.sh
+++ b/test/test-install-systemd.sh
@@ -26,20 +26,24 @@ assert_file $TMP/systemd.service "--driver direct"
 assert_file $TMP/systemd.service "User=$CURRENT_USER"
 assert_file $TMP/systemd.service "Group=$CURRENT_GROUP"
 
-# Should create a systemd service at the specified path
-assert_exit 0 $CMD --port 7777 \
-              --job-file $TMP/systemd-with-docker.service \
-              --user $CURRENT_USER \
-              --base $TMP/deeply/nested/sl-pm \
-              --driver docker \
-              --systemd
+if docker info; then
+  # Should create a systemd service at the specified path
+  assert_exit 0 $CMD --port 7777 \
+                --job-file $TMP/systemd-with-docker.service \
+                --user $CURRENT_USER \
+                --base $TMP/deeply/nested/sl-pm \
+                --driver docker \
+                --systemd
 
-# Simple lines that should be in the service file for this config
-assert_file $TMP/systemd-with-docker.service "ExecStart=$(node -p process.execPath)"
-assert_file $TMP/systemd-with-docker.service "WorkingDirectory=$HOME"
-assert_file $TMP/systemd-with-docker.service "Description=StrongLoop Process Manager"
-assert_file $TMP/systemd-with-docker.service "--driver docker"
-assert_file $TMP/systemd-with-docker.service "User=$CURRENT_USER"
-assert_file $TMP/systemd-with-docker.service "Group=docker"
+  # Simple lines that should be in the service file for this config
+  assert_file $TMP/systemd-with-docker.service "ExecStart=$(node -p process.execPath)"
+  assert_file $TMP/systemd-with-docker.service "WorkingDirectory=$HOME"
+  assert_file $TMP/systemd-with-docker.service "Description=StrongLoop Process Manager"
+  assert_file $TMP/systemd-with-docker.service "--driver docker"
+  assert_file $TMP/systemd-with-docker.service "User=$CURRENT_USER"
+  assert_file $TMP/systemd-with-docker.service "Group=docker"
+else
+  skip "docker not available, skipping tests that require it"
+fi
 
 unset SL_INSTALL_IGNORE_PLATFORM

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -101,7 +101,7 @@ assert_file $TMP/upstart.conf "STRONGLOOP_PM_SKIP_DEFAULT_INSTALL=true"
 assert_exit 0 $CMD --port 7777 \
                    --job-file $TMP/upstart-with-basedir.conf \
                    --user $CURRENT_USER \
-                   --driver docker
+                   --driver direct
 
 # TODO: find another way to test this without depending on the real $HOME
 if [ -d $HOME/.strong-pm ]; then
@@ -112,17 +112,21 @@ else
   assert_file $TMP/upstart-with-basedir.conf "--base $HOME"
 fi
 
-# Should create an upstart job at the specified path
-assert_exit 0 $CMD --port 7777 \
-		   --base-port 8888 \
-                   --job-file $TMP/upstart-with-docker.conf \
-                   --user $CURRENT_USER \
-                   --driver docker
-assert_not_file $TMP/upstart-with-docker.conf "--driver direct"
-assert_file $TMP/upstart-with-docker.conf "--driver docker"
-assert_file $TMP/upstart-with-docker.conf "setuid $CURRENT_USER"
-assert_file $TMP/upstart-with-docker.conf "setgid docker"
-assert_file $TMP/upstart-with-docker.conf "--listen 7777"
-assert_file $TMP/upstart-with-docker.conf "--base-port 8888"
+if docker info; then
+  # Should create an upstart job at the specified path
+  assert_exit 0 $CMD --port 7777 \
+                     --base-port 8888 \
+                     --job-file $TMP/upstart-with-docker.conf \
+                     --user $CURRENT_USER \
+                     --driver docker
+  assert_not_file $TMP/upstart-with-docker.conf "--driver direct"
+  assert_file $TMP/upstart-with-docker.conf "--driver docker"
+  assert_file $TMP/upstart-with-docker.conf "setuid $CURRENT_USER"
+  assert_file $TMP/upstart-with-docker.conf "setgid docker"
+  assert_file $TMP/upstart-with-docker.conf "--listen 7777"
+  assert_file $TMP/upstart-with-docker.conf "--base-port 8888"
+else
+  skip "docker not available, skipping tests that require it"
+fi
 
 unset SL_INSTALL_IGNORE_PLATFORM

--- a/test/test-server-metadata.js
+++ b/test/test-server-metadata.js
@@ -133,6 +133,7 @@ function testObjTrackingStop(t) {
 }
 
 function testWorkerExitState(t) {
+  t.plan(7 + 1);
   server.once('exit', function() {
     ServiceProcess.findOne({where: {workerId: 1}}, function(err, proc) {
       t.ifError(err);
@@ -142,7 +143,6 @@ function testWorkerExitState(t) {
       t.assert(proc.startTime, 'Start time should be set');
       t.assert(proc.stopTime, 'Stop time should be set');
       t.assert(proc.stopReason, 'Stop reason should be set');
-      t.end();
     });
   });
   pmctl('set-size 1 0')(t, true);


### PR DESCRIPTION
If the test environment does not have a working docker installation then
the installer fails. That makes the tests a lot less portable than they
should be.

This should allow the tests to pass on `cis-jenkins`.