### PR TITLE
package: update strong-runner to 7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "strong-pm",
   "description": "StrongLoop Process Manager",
-  "version": "5.2.4",
+  "version": "6.0.0",
+  "engines": {
+    "node": ">=4"
+  },
   "keywords": [
     "StrongLoop",
     "agent",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "strong-fork-cicada": "^1.1.2",
     "strong-mesh-models": "^8.0.0",
     "strong-npm-ls": "^1.0.0",
-    "strong-runner": "^5.x",
+    "strong-runner": "^6.x",
     "strong-service-install": "^2.0.0",
     "strong-spawn-npm": "^1.0.0",
     "strong-tunnel": "^1.1.1",


### PR DESCRIPTION
6.x uses appmetrics instead of strong-agent

Depends on https://github.com/strongloop/strong-runner/pull/21

connected to https://github.com/strongloop-internal/scrum-nodeops/issues/1465
