### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 6
+  - 8
+  - 10


### PR DESCRIPTION
Currently Travis CI fails because the .travis.yml does not exist.